### PR TITLE
Revert "Temporary remove test gems to fix test build."

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,14 +53,14 @@ gem "nokogiri", "1.8.1"
 gem "factory_girl", "~> 4.0", group: [:test, :development]
 gem "rspec"
 gem "blacklight_advanced_search"
-# group :test, :development do
-#   gem 'ci_reporter_rspec'
-#   gem 'capybara'
-#   gem 'selenium-webdriver'
-#   gem 'rspec-rails'
-#   gem 'rspec-solr'
-#   gem 'simplecov', :require => false
-# end
+group :test, :development do
+  gem 'ci_reporter_rspec'
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'rspec-rails'
+  gem 'rspec-solr'
+  gem 'simplecov', :require => false
+end
 gem 'paperclip', '4.3.6'
 gem 'blacklight_google_analytics'
 gem 'comfortable_mexican_sofa', '1.12.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,20 @@ GEM
       sass (>= 3.3.4)
     bootstrap_form (2.7.0)
     builder (3.2.3)
+    capybara (3.0.3)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -116,6 +128,7 @@ GEM
     devise-guests (0.6.0)
       devise
     diff-lcs (1.3)
+    docile (1.3.0)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.9.0)
@@ -252,6 +265,8 @@ GEM
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -260,6 +275,17 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-rails (3.7.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-solr (2.0.0)
+      rspec (~> 3.0)
+      rspec-collection_matchers
     rspec-support (3.7.1)
     ruby_parser (3.11.0)
       sexp_processor (~> 4.9)
@@ -279,7 +305,15 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    selenium-webdriver (3.12.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sexp_processor (4.11.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     solrizer (3.4.1)
       activesupport
       daemons
@@ -316,6 +350,8 @@ GEM
     warden (1.2.7)
       rack (>= 1.0)
     xml-simple (1.1.5)
+    xpath (3.0.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -328,6 +364,8 @@ DEPENDENCIES
   blacklight_advanced_search
   blacklight_google_analytics
   blacklight_range_limit
+  capybara
+  ci_reporter_rspec
   coffee-rails (~> 4.1.0)
   comfortable_mexican_sofa (= 1.12.9)
   devise
@@ -344,8 +382,12 @@ DEPENDENCIES
   paperclip (= 4.3.6)
   rails (= 4.2.10)
   rspec
+  rspec-rails
+  rspec-solr
   sass-rails (~> 5.0.1)
   sdoc (~> 0.4.0)
+  selenium-webdriver
+  simplecov
   spring
   sqlite3
   therubyracer


### PR DESCRIPTION
Reverts ualbertalib/discovery#1160

The plot thickens.  It failed on both servers, with the same message on both, during "rake assets:precompile"... 
```
fatal: [forest]: FAILED! => {"changed": true, "cmd": "bundle exec rake assets:precompile", "delta": "0:00:01.934908", "end": "2018-05-22 11:26:49.521359", "failed": true, "rc": 1, "start": "2018-05-22 11:26:47.586451", "stderr": 
"DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. 
See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. 
(called from require at /usr/lib64/ruby/gems/2.1.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:76)\n
rake aborted!\nLoadError: cannot load such file -- ci/reporter/rake/rspec\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'\n
/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'\n
/var/www/sites/blacklight/lib/tasks/spec.rake:2:in `<top (required)>'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'\n
/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'\n
/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/railties-4.2.10/lib/rails/engine.rb:658:in `block in run_tasks_blocks'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/railties-4.2.10/lib/rails/engine.rb:658:in `each'\n/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/railties-4.2.10/lib/rails/engine.rb:658:in `run_tasks_blocks'\n
/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/railties-4.2.10/lib/rails/application.rb:452:in `run_tasks_blocks'\n
/var/www/sites/blacklight/vendor/ruby/2.1.0/gems/railties-4.2.10/lib/rails/engine.rb:453:in `load_tasks'\n/var/www/sites/blacklight/Rakefile:6:in `<top (required)>'\n(See full trace by running task with --trace)", "stdout": "", "stdout_lines": [], "warnings": []}
```