### PR TITLE
correct the capitalization for the view citation label - fixes #1058

### DIFF
--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -48,7 +48,7 @@
       <li><a href="/search_history">View Search History</a></li>
       <% if (@document.respond_to?(:export_as_mla_citation_txt) || @document.respond_to?(:export_as_apa_citation_txt)) %>
         <li class="cite">
-          <%= link_to t('View Citation (MLA/APA/Chicago)'), citation_catalog_path(:id => @document), {:id => 'citeLink', :class => 'lightboxLink'} %>
+          <%= link_to 'View Citation (MLA/APA/Chicago)', citation_catalog_path(:id => @document), {:id => 'citeLink', :class => 'lightboxLink'} %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
The translation/i18n in blacklight in missing completed. Don't know why this one uses i18n string. This is not the right way to fix the issue, but it is the quickest way. And we will need to deal with i18n issue more holistically when/if we refactor the views. 