### PR TITLE
update changelog for release 3.0.87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.0.87] - 2018-09-26
+### Changed
+- Fix diacritics font issues [Issue#1268](https://github.com/ualbertalib/discovery/issues/1268)
+- Reword text on Advanced Search page [Issue#1254](https://github.com/ualbertalib/discovery/issues/1254)
+- MAP_OS location is not mapped/displays as blank [Issue#1135](https://github.com/ualbertalib/discovery/issues/1135)
+- seeing Alberta Health Services - Women's Health in list view as library name for NLC_INT [Issue#1127](https://github.com/ualbertalib/discovery/issues/1127)
+- TOC not wrapping around Tools box [Issue#1088](https://github.com/ualbertalib/discovery/issues/1088)
+- Remove call number attribute from advanced search [Issue#755] (https://github.com/ualbertalib/discovery/issues/755)
+- Make Librarian View a pop-up window [Issue#1242](https://github.com/ualbertalib/discovery/issues/1242)
+- changed advanced search text. Fixed CMS login credentials to use secrets.yml
+
 ## [3.0.86] - 2018-09-21
 ### Added
 - Github issue templates [PR#1271](https://github.com/ualbertalib/discovery/pull/1271)


### PR DESCRIPTION
Changlog update for new release 3.0.87. 

Tagged a new release instead of using 3.0.86.1 as @nnunn added more UI changes and fixes multiple issues in the backlog. 