### PR TITLE
removing slow code on profile page

### DIFF
--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -315,10 +315,6 @@
           - @photo_link = URI.encode(@photo_link_dirty)
           - @no_photo = "staff-photos/thumbs/none.jpg"
           %td.staff-images
-            - res = Net::HTTP.get_response(URI.parse(@photo_link))
-            - if res.code.to_i == 200
-              = link_to image_tag(@photo_link), profile_path(profile)
-            - else
               = link_to image_tag(@no_photo), profile_path(profile)
           %td
             %h2

--- a/app/views/profiles/index.html.haml
+++ b/app/views/profiles/index.html.haml
@@ -315,7 +315,7 @@
           - @photo_link = URI.encode(@photo_link_dirty)
           - @no_photo = "staff-photos/thumbs/none.jpg"
           %td.staff-images
-              = link_to image_tag(@no_photo), profile_path(profile)
+            = link_to image_tag(@no_photo), profile_path(profile)
           %td
             %h2
               = link_to((profile.first_name.capitalize+" "+profile.last_name.capitalize), profile_path(profile))


### PR DESCRIPTION
Removing code which is slowing down the profile page. This code went and checked if a staff member's photo exists on www2 and if it doesn't exist displays a generic image. However, this process is slowing down the page load considerable. Therefor, I have removed it and instead added a thumbnail for all staff - generic ones for those without images.