### PR TITLE
Add letter opener gem to make testing emails easier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,30 +47,32 @@ gem 'rollbar'
 
 group :test, :development do
   gem 'sdoc', require: false
-  
+
   gem 'capybara'
   gem 'selenium-webdriver'
-  
+
   gem 'factory_bot'
-  
+
   gem "rspec"
   gem 'rspec-rails'
   gem 'rspec-solr'
-  
+
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'
 
   gem 'rubocop', '~> 0.56.0', require: false
-  
+
   gem 'scss_lint', '>= 0.56.0', require: false
-  
+
   gem 'simplecov', require: false
 end
 
 group :development do
   gem 'better_errors', '>= 2.3.0'
   gem 'binding_of_caller'
+
+  gem 'letter_opener'
 
   gem 'brakeman'
   gem 'listen', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,10 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     kramdown (1.17.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
     libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -424,6 +428,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jettywrapper (~> 2.0.3)
   jquery-rails
+  letter_opener
   listen (~> 3.0)
   mysql2 (~> 0.4.10)
   nokogiri (~> 1.8.5)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,8 @@
-# *** WARNING *** Don't change this file ! 
+# *** WARNING *** Don't change this file !
 #
 # This file is a placeholder.  In Dev/Test/Prod, this file will
 # be replaced by ansible, whence we have 3 separate templates, one
-# for each environment! 
+# for each environment!
 # See:
 # [nmacgreg@its004nm2 ansible-dev-master]$ ls -al roles/blacklight-application/templates/database*
 # -rwxrwxr-x. 1 nmacgreg nmacgreg 643 Apr 22 09:01 roles/blacklight-application/templates/database.yml
@@ -27,7 +27,7 @@ development:
 test:
   <<: *default
   database: discovery_test
-  
+
 uat:
   <<: *default
   url: <%= Rails.application.secrets.database_url %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,9 +37,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   #
-  config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_options = {from: 'no-reply@ualberta.ca'}
 end
-

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,6 @@ Rails.application.configure do
   #
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_options = {from: 'no-reply@ualberta.ca'}
 end


### PR DESCRIPTION
First step of many for doing the request forms:

Brings in this gem: https://github.com/ryanb/letter_opener

Email in development environment now opens a nice new tab displaying the email that was sent out:
![image](https://user-images.githubusercontent.com/1930474/47175548-9cc53300-d2d0-11e8-9b31-2f0f6dfbc48b.png)

Instead of hiding the contents of the email inside the console.