### PR TITLE
Add editorconfig dot file so everyone has consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Noticed from last PR there was a bunch of space diffs among other things. Lets align our editors to be on the same page.

This brings in an EditorConfig which helps developers maintain consistent coding styles between different editors/IDEs.

More info and links to plugins (if your editor doesnt support editorconfig) here: https://editorconfig.org/