### PR TITLE
Bring over script to provision test/dev solr cores from jupiter to fix docker issue

### DIFF
--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -27,7 +27,4 @@ services:
        - "8983:8983"
     volumes:
       - solr:/opt/solr/server/solr/mycores
-    entrypoint:
-      - solr-precreate
-      - discovery-test
-      - /myconfig
+      - ./lib/solr/solr-precreate-discovery.sh:/docker-entrypoint-initdb.d/solr-precreate-discovery.sh

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -27,4 +27,4 @@ services:
        - "8983:8983"
     volumes:
       - solr:/opt/solr/server/solr/mycores
-      - ./lib/solr/solr-precreate-discovery.sh:/docker-entrypoint-initdb.d/solr-precreate-discovery.sh
+      - ./lib/docker/solr-precreate-discovery.sh:/docker-entrypoint-initdb.d/solr-precreate-discovery.sh

--- a/lib/docker/solr-precreate-discovery.sh
+++ b/lib/docker/solr-precreate-discovery.sh
@@ -20,20 +20,20 @@ else
     coresdir=$SOLR_HOME
 fi
 
-coredir_dev="$coresdir/development"
+coredir_dev="$coresdir/discovery"
 if [[ ! -d $coredir_dev ]]; then
-    cp -r /config/ $coredir_dev
+    cp -r /myconfig/ $coredir_dev
     touch "$coredir_dev/core.properties"
-    echo "created development core"
+    echo "created discovery core"
 else
-    echo "core development already exists"
+    echo "core discovery already exists"
 fi
 
-coredir_test="$coresdir/test"
+coredir_test="$coresdir/discovery-test"
 if [[ ! -d $coredir_test ]]; then
-    cp -r /config/ $coredir_test
+    cp -r /myconfig/ $coredir_test
     touch "$coredir_test/core.properties"
-    echo "created test core"
+    echo "created discovery-test core"
 else
-    echo "core test already exists"
+    echo "core discovery-test already exists"
 fi

--- a/lib/docker/solr-precreate-discovery.sh
+++ b/lib/docker/solr-precreate-discovery.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# This is for docker! Customized script for our discovery project.
+# As discovery needs both a development and test core.
+#
+# This script was mostly stolen from the official solr-precreate script:
+# https://github.com/docker-solr/docker-solr/blob/master/scripts/solr-precreate
+set -e
+
+echo "Executing $0 $@"
+
+if [[ "$VERBOSE" = "yes" ]]; then
+    set -x
+fi
+
+if [[ -z $SOLR_HOME ]]; then
+    coresdir="/opt/solr/server/solr/mycores"
+    mkdir -p $coresdir
+else
+    coresdir=$SOLR_HOME
+fi
+
+coredir_dev="$coresdir/development"
+if [[ ! -d $coredir_dev ]]; then
+    cp -r /config/ $coredir_dev
+    touch "$coredir_dev/core.properties"
+    echo "created development core"
+else
+    echo "core development already exists"
+fi
+
+coredir_test="$coresdir/test"
+if [[ ! -d $coredir_test ]]; then
+    cp -r /config/ $coredir_test
+    touch "$coredir_test/core.properties"
+    echo "created test core"
+else
+    echo "core test already exists"
+fi


### PR DESCRIPTION
#1282 

Temporary fix to get this working without the pain of constantly having to take down and change docker configs to run discovery in both dev and test modes.

![image](https://user-images.githubusercontent.com/1930474/47672499-d1aa7300-db77-11e8-8bcd-2dc1e2a774ae.png)

But we should maybe spend some time thinking about refactoring the docker stuff to be more in align with our other apps like jupiter (or if theres improvements/better ways to do this for jupiter codebase then by all means we can improve this as well)