### PR TITLE
remove unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,8 @@ gem 'rails', '4.2.10'
 gem 'mysql2', '~> 0.4.10'
 
 # Assets (CSS/JS) stuff
-gem 'coffee-rails', '~> 4.2.2'
-gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 gem 'sass-rails', '~> 5.0.1'
-gem 'therubyracer', platforms: :ruby
 gem 'turbolinks', '5.2.0'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,9 +166,6 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
-    jbuilder (2.7.0)
-      activesupport (>= 4.2.0)
-      multi_json (>= 1.2)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -193,7 +190,6 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.6.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.19)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -281,7 +277,6 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (5.1.0)
-    ref (2.0.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -371,9 +366,6 @@ GEM
     temple (0.8.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -409,13 +401,11 @@ DEPENDENCIES
   brakeman
   capybara
   chromedriver-helper
-  coffee-rails (~> 4.2.2)
   comfortable_mexican_sofa (= 1.12.9)
   devise
   devise-guests
   factory_bot
   friendly_id
-  jbuilder (~> 2.0)
   jquery-rails
   letter_opener
   listen (~> 3.0)
@@ -438,7 +428,6 @@ DEPENDENCIES
   selenium-webdriver
   simplecov
   spring
-  therubyracer
   turbolinks (= 5.2.0)
   uglifier (>= 1.3.0)
 


### PR DESCRIPTION
jbuilder and coffee-rails don't appear to be used.  Removing them!
We shouldn't be using therubyracer in production either... https://devcenter.heroku.com/articles/rails-asset-pipeline#therubyracer rails/rails#29285

closes #1375 