### PR TITLE
Remove uat mail intercept and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and releases in Discovery project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mail catcher docker container for checking mail on UAT [#1342](https://github.com/ualbertalib/discovery/pull/1342)
+
+### Removed
+- Email Interceptor for UAT environments [PR#1387](https://github.com/ualbertalib/discovery/pull/1387)
 
 ## [3.0.91] - 2018-11-03
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Integration tests (run against <http://search-test.library.ualberta.ca/>)
 2.  `bundle exec rake comfortable_mexican_sofa:cmssetup` to setup the CMS
 3.  create cron jobs to ingest `bundle exec rake ingest[sfx]`, `bundle exec rake ingest[databases]` and clean session table `bundle exec rake sessions:cleanup`
 
+## UAT
+Go [here](https://github.com/ualbertalib/di_internal/blob/master/System-Adminstration/UAT-Environment.md#access-discovery-uat-instance) for information about accessing Discovery UAT instance.
+
 ## Ingest
 
 The standard library cataloguing data format is [MARC](https://www.loc.gov/marc/marcdocz.html). MARC uses numeric fields to contain bibliographic information in the form of text strings that use a [content standard](https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description) to format the text and, perhaps more importantly, the punctuation. Each MARC field can be subdivided into alphabetical subfields which generally either a) containing repeated elements or b) subdivide the text string. MARC fields and subfields are often written out as e.g. **245$a** which means field number 245 (= title), subfield a.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -46,8 +46,6 @@ uat:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   database_url: <%= ENV['DATABASE_URL'] %>
   solr_url: <%= ENV['SOLR_URL'] %>
-  intercept_mail: true
-  intercept_mail_address: 'dittest@ualberta.ca'
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   solr_url: <%= ENV['SOLR_URL'] %>


### PR DESCRIPTION
From https://github.com/ualbertalib/di_internal/pull/38#issuecomment-437166354
> For now probably can just give a link to this section of the document: https://github.com/ualbertalib/di_internal/blob/master/System-Adminstration/UAT-Environment.md#access-discovery-uat-instance
> 
> Also just noticed we can probably turn off email intercepting on UAT now that we got mailcatcher (as mailcatcher does the intercepting)


