### PR TITLE
Change application name to Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 - Refactored to not use javascript to display electronic access links [PR#1398](https://github.com/ualbertalib/discovery/pull/1398)
 - Application Name to 'University of Alberta Libraries' [#1243](https://github.com/ualbertalib/discovery/issues/1243)
 - Changed who RCRF read on site request form emails [#1403](https://github.com/ualbertalib/discovery/issues/1403)
+- Change application name to Discovery [#1415](https://github.com/ualbertalib/discovery/issues/1415)
 
 ## [3.0.92] - 2018-11-16
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,7 @@ require 'csv'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module VanillaBlacklight
+module Discovery
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Previously was `VanillaBlacklight` which isn't accurate anymore (and horrible name to begin with?)