### PR TITLE
tell travis to test newer versions of ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ addons:
   chrome: stable
 rvm:
   - 2.1.5
-  - 2.4
+  - 2.5
 cache: bundler
 bundler_args: --without development production --jobs=3 --retry=3
 before_script:


### PR DESCRIPTION
This will let us know that this project can be deployed against newer
versions of ruby. Currently 2.1.5 is used in production and we strongly
want to change this.