### PR TITLE
update changelog for v3.0.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 -  Added more subfields (t, r, and g) to contents notes [#1121](https://github.com/ualbertalib/discovery/issues/1121)
 -  Added more subfields (f, k) to title [#978](https://github.com/ualbertalib/discovery/issues/978)
 
+## [3.0.96] - 2019-02-07
+
 ### Fixed
 -   Don't show conditions of use unless there is something to show [PR#1479](https://github.com/ualbertalib/discovery/pull/1479)
 


### PR DESCRIPTION
We did a [hotfix release](https://github.com/ualbertalib/discovery/releases/tag/3.0.96) for the conditions of use bug https://github.com/ualbertalib/discovery/commit/f56d63d2fadd77a81d3ff23a52934e6d970e93f8 at the request of @seanluyk 

Adding this hotfix release changelog to the master branch (the commit is already there).