### PR TITLE
remove erb-lint so that we can deploy expediently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.0.98] - 2019-02-21
+
+### Removed
+- ERB-lint prevented the previous release from being deployed expediently because of Ruby 2.1.5 in production. [PR#1507](https://github.com/ualbertalib/discovery/pull/1507)
+
 ## [3.0.97] - 2019-02-11
 
 ### Removed

--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,6 @@ group :development do
   gem 'better_errors', '>= 2.3.0'
   gem 'binding_of_caller'
 
-  gem 'erb_lint', '0.0.28', require: false
-
   gem 'letter_opener'
 
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,14 +54,6 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-    better_html (1.0.12)
-      actionview (>= 4.0)
-      activesupport (>= 4.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      html_tokenizer (~> 0.0.6)
-      parser (>= 2.4)
-      smart_properties
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     blacklight (5.15.0)
@@ -121,13 +113,6 @@ GEM
       devise
     diff-lcs (1.3)
     docile (1.3.1)
-    erb_lint (0.0.28)
-      activesupport
-      better_html (~> 1.0.7)
-      html_tokenizer
-      rainbow
-      rubocop (~> 0.51)
-      smart_properties
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -137,7 +122,6 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.8)
-    html_tokenizer (0.0.7)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -302,7 +286,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    smart_properties (1.13.1)
     solrizer (3.4.1)
       activesupport
       daemons
@@ -363,7 +346,6 @@ DEPENDENCIES
   chromedriver-helper
   devise
   devise-guests
-  erb_lint (= 0.0.28)
   factory_bot
   jquery-rails
   letter_opener


### PR DESCRIPTION
Upgrading Ruby to 2.5.x (#1506) is in progress but is still a couple weeks away.  When that's complete we should re-introduce this gem (#1506).

