### PR TITLE
pin version of bundler in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 tmp
 log
 coverage/
+data/
 .bundle
 .ruby-version
 vendor/bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+-  pinned the version of bundler used in the Dockerfile [PR#1511](https://github.com/ualbertalib/discovery/pull/1511)
+
 ## [3.0.98] - 2019-02-21
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ CMD ["/sbin/my_init"]
 
 RUN bash -lc 'rvm install ruby-2.1.5'
 RUN bash -lc 'rvm --default use ruby-2.1.5'
-RUN bash -lc 'gem install bundler'
+RUN bash -lc 'gem install bundler -v 1.17.3'
 
 RUN apt-get update -qq \
     && apt-get install -y build-essential \


### PR DESCRIPTION
so that it is compatible with Ruby 2.1.5.

```
Step 7/22 : RUN bash -lc 'gem install bundler -v 1.17.3'
 ---> Running in 1b9994761f3f
mesg: ttyname failed: Inappropriate ioctl for device
Successfully installed bundler-1.17.3
1 gem installed
Removing intermediate container 1b9994761f3f
 ---> f2b9bfa78095
```