### PR TITLE
turn off turbolinks on the show page for range_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+-   Range Facet missing context after following show page link [#1290](https://github.com/ualbertalib/discovery/issues/1290)
+
 ## [3.0.99] - 2019-02-27
 
 ### Removed

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -6,41 +6,36 @@
       <dt class="blacklight-<%= solr_fname.parameterize %>">
         <%= render_document_show_field_label document, field: solr_fname %>
       </dt>
+      <% value = render_document_show_field_value document, field: solr_fname %>
       <% if @linked_fields.include? solr_fname %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <a href="/catalog?q=&quot;<%= render_document_show_field_value(document, field: solr_fname).tr(' ', '+') %>&quot;">
-            <%= render_document_show_field_value document, field: solr_fname %>
-          </a>
+          <%= link_to value, catalog_index_path(q: "\"#{value}\"") %>
         </dd>
       <% elsif solr_fname == "title_series_t" %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <a href="/<%= params[:controller] %>?title=&quot;<%= render_document_show_field_value(document, field: solr_fname).split(';').first.strip.tr(' ', '+') %>&quot;&search_field=advanced">
-            <%= render_document_show_field_value document, field: solr_fname %>
-          </a>
+          <%= link_to value, catalog_index_path(title: "\"#{value}\"", search_field: 'advanced') %>
         </dd>
       <% elsif solr_fname == "author_display" %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <a href="/<%= params[:controller] %>?author=<%= render_document_show_field_value(document, field: solr_fname).tr(' ', '+') %>&search_field=advanced">
-            <%= render_document_show_field_value document, field: solr_fname %>
-          </a>
+          <%= link_to value, catalog_index_path(author: value, search_field: 'advanced') %>
         </dd>
       <% elsif solr_fname == "author_addl_t" and @additional_authors %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
           <% for author in @additional_authors %>
-            <a href="/catalog?q=&quot;<%= author.tr(' ', '+') %>&quot;"><%= author %></a><br />
+            <%= link_to author, catalog_index_path(q: "\"#{author}\"") %>
           <% end %>
         </dd>
       <% elsif solr_fname == "contents_tesim" %>
         <dd class="blacklight-<%= solr_fname.parameterize %>" style="font-size:75%">
           <ul>
-            <% render_document_show_field_value(document, field: solr_fname).split('--').each do |note| %>
+            <% value.split('--').each do |note| %>
               <li><%= sanitize(note) %></li>
             <% end %>
           </ul>
         </dd>
     <% else %>
       <dd class="blacklight-<%= solr_fname.parameterize %>">
-        <%= render_document_show_field_value document, field: solr_fname %>
+        <%= value %>
       </dd>
     <% end %>
   <% end -%>

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -9,20 +9,20 @@
       <% value = render_document_show_field_value document, field: solr_fname %>
       <% if @linked_fields.include? solr_fname %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <%= link_to value, catalog_index_path(q: "\"#{value}\"") %>
+          <%= link_to value, catalog_index_path(q: "\"#{value}\""), data: { turbolinks: false } %>
         </dd>
       <% elsif solr_fname == "title_series_t" %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <%= link_to value, catalog_index_path(title: "\"#{value}\"", search_field: 'advanced') %>
+          <%= link_to value, catalog_index_path(title: "\"#{value}\"", search_field: 'advanced'), data: { turbolinks: false } %>
         </dd>
       <% elsif solr_fname == "author_display" %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
-          <%= link_to value, catalog_index_path(author: value, search_field: 'advanced') %>
+          <%= link_to value, catalog_index_path(author: value, search_field: 'advanced'), data: { turbolinks: false } %>
         </dd>
       <% elsif solr_fname == "author_addl_t" and @additional_authors %>
         <dd class="blacklight-<%= solr_fname.parameterize %>">
           <% for author in @additional_authors %>
-            <%= link_to author, catalog_index_path(q: "\"#{author}\"") %>
+            <%= link_to author, catalog_index_path(q: "\"#{author}\""), data: { turbolinks: false } %>
           <% end %>
         </dd>
       <% elsif solr_fname == "contents_tesim" %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -37,7 +37,7 @@
               <% @subjects.each do |subject| %>
                 <li>
                   <% subject.each_with_index do |asubject, index| %>
-                    <%= link_to asubject, catalog_index_path(q: subject_query(subject.take(index + 1)), view: 'brief', search_field: 'subject') %>
+                    <%= link_to asubject, catalog_index_path(q: subject_query(subject.take(index + 1)), view: 'brief', search_field: 'subject'), data: { turbolinks: false } %>
                     <% unless index == subject.size - 1 %>
                       <span class="glyphicon glyphicon-menu-right"></span>
                     <% end %>


### PR DESCRIPTION
![screenshot from 2019-03-01 13-18-04](https://user-images.githubusercontent.com/1220762/53668827-3b27b480-3c32-11e9-833c-6fbb0dffcdcb.png)

The range_limit XHR request is what gives the context to popluate the
range facet. While turbolinks helps to improve the perceived
performance, it prevents the XHR range_limit request from being loaded.
Links with Turbolinks disabled will be handled normally by the browser.

Also refactor links on show page to use rails helper link_to

#1290