### PR TITLE
Pin blacklight range limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Added
 - SOLR_HEAP env var to lightweight docker to avoid Java out of heap error with larger indexes [PR#1536](https://github.com/ualbertalib/discovery/pull/1536)
+
+### Fixed
+- pin version of blacklight_range_limit to restore interactive behaviour [PR#1536](https://github.com/ualbertalib/discovery/pull/1536)
+
 ## [3.0.100] - 2019-03-08
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Added
+- SOLR_HEAP env var to lightweight docker to avoid Java out of heap error with larger indexes [PR#1536](https://github.com/ualbertalib/discovery/pull/1536)
 ## [3.0.100] - 2019-03-08
 
 ### Security

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'blacklight', '5.15.0'
 gem 'blacklight-marc', '~> 5.10.0'
 gem 'blacklight_advanced_search'
 gem 'blacklight_google_analytics'
-gem 'blacklight_range_limit'
+gem 'blacklight_range_limit', '~> 5.2.0'
 
 # Authentication
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,11 +79,10 @@ GEM
       blacklight (~> 5.15)
       parslet
     blacklight_google_analytics (0.0.1.pre3)
-    blacklight_range_limit (7.0.0)
-      blacklight
+    blacklight_range_limit (5.2.0)
+      blacklight (~> 5.15)
       jquery-rails
-      rails (>= 3.0)
-      tether-rails
+      rails (>= 3.0, < 5.0)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -325,8 +324,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     stomp (1.4.8)
-    tether-rails (1.4.0)
-      rails (>= 3.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -363,7 +360,7 @@ DEPENDENCIES
   blacklight-marc (~> 5.10.0)
   blacklight_advanced_search
   blacklight_google_analytics
-  blacklight_range_limit
+  blacklight_range_limit (~> 5.2.0)
   bootstrap_form (~> 2.7.0)
   brakeman
   capybara

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -23,6 +23,8 @@ services:
 
   solr:
     image: ualbertalib/blacklight_solr_conf
+    environment:
+       - SOLR_HEAP=800m
     ports:
        - "8983:8983"
     volumes:


### PR DESCRIPTION
To address the issue noted here https://github.com/ualbertalib/discovery/pull/1520#issuecomment-471663175
![Screenshot from 2019-03-12 10-54-56](https://user-images.githubusercontent.com/1220762/54219520-4a6df400-44b5-11e9-8ec8-a4dac7737b4a.png)

This occurred because the version of blacklight_range_limit was bumped (with the negative consequences noted) https://github.com/ualbertalib/discovery/pull/1528/commits/381faff26a6550e40d1f363485ea566acf6610f7#diff-e79a60dc6b85309ae70a6ea8261eaf95R82

While I'm here, I'll also add a config change to the Solr docker in the lightweight config.
