### PR TITLE
Address key length issue with refworks/bookmarks after ruby upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Fixed
 - use safe navigation operator fixes nil error in Symphony Service summary holdings [#1571](https://github.com/ualbertalib/discovery/issues/1571)
+- refworks export with encrypted user behavior restored [#1549](https://github.com/ualbertalib/discovery/issues/1549)
 
 ## [3.0.104] - 2019-03-27
 ### Fixed

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,8 +1,21 @@
-
 class BookmarksController < CatalogController
   include Blacklight::Bookmarks
 
   def action_success_redirect_path
     bookmarks_path
+  end
+
+  # monkey patch this method which is throwing `key must be 32 bytes` error after upgrading to Ruby 2.5
+  def export_secret_token(salt)
+    secret_key_generator.generate_key(salt)[0..(ActiveSupport::MessageEncryptor.key_len - 1)]
+  end
+
+  # cribbed from https://github.com/projectblacklight/blacklight/blob/8b9041544553ce0dd0d979f9f39f78d94b30b46d/app/controllers/concerns/blacklight/token_based_user.rb#L46-L76
+  def secret_key_generator
+    @secret_key_generator ||= begin
+      # TODO: this is appropriate for Rails <= 5.1
+      # update to Rails.application.credentials.secret_key_base for Rails 5.2+
+      ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base)
+    end
   end
 end

--- a/app/views/bookmarks/_refworks.html.erb
+++ b/app/views/bookmarks/_refworks.html.erb
@@ -1,5 +1,5 @@
 <% if @document_list.any? {|d| d.exports_as? :refworks_marc_txt } %>
-  <li class="refworks">
+  <li class="nav-item">
     <%= link_to t('blacklight.tools.refworks'), refworks_export_url(url: bookmarks_export_url(:refworks_marc_txt, params_for_search)), class: 'btn btn-default', id: 'refworksLink', target: '_blank' %>
   </li>
 <% end %>

--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -4,7 +4,5 @@
       <%= inner %>
     </li>
   <% end %>
-
-  <%# March 20 2019: Issue 1549: after the ruby upgdate to 2.5.3, refworks export with encrypted user behavior is broken, we temporarily removed the refwork export to recover the bookmark feature. TO-DO: find a permanent fix for this issue %>
-  <%# = render_marc_tools %> 
+  <%= render_marc_tools %>
 </ul>

--- a/app/views/bookmarks/_tools.html.erb
+++ b/app/views/bookmarks/_tools.html.erb
@@ -1,7 +1,7 @@
   <ul class="<%= controller_name %>Tools nav nav-pills">
   <%= render_show_doc_actions document_list, document: nil, document_list: @document_list, url_opts: sanitize_search_params(params) do |config, inner| %>
     <li class="nav-item">
-      <%= inner %>
+      <%= inner.insert(3, 'class="btn btn-default"') %>
     </li>
   <% end %>
   <%= render_marc_tools %>

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Bookmarks', type: :feature do
+  describe 'navigating from the homepage' do
+    it 'has a link to the history page' do
+      visit '/'
+      fill_in 'q', with: 'Shakespeare'
+      click_button 'search'
+      click_link 'Go to bookmarks'
+      expect(page).to have_content 'You have no bookmarks'
+    end
+  end
+
+  it 'add and remove bookmarks from search results' do
+    visit '/'
+    fill_in 'q', with: 'Shakespeare'
+    click_button 'search'
+    within first('div.document') do
+      check 'Bookmark'
+      expect(page).to have_content 'In Bookmarks'
+    end
+
+    fill_in 'q', with: 'Shakespeare'
+    click_button 'search'
+    within first('div.document') do
+      uncheck 'In Bookmarks'
+      expect(page).to have_content 'Bookmark'
+    end
+  end
+
+  it 'adds and delete bookmarks from the show page' do
+    VCR.use_cassette('item_result') do
+      visit 'catalog/1001523'
+      expect(page).to have_content 'Bookmark'
+      check 'Bookmark'
+      expect(page).to have_content 'In Bookmarks'
+      uncheck 'In Bookmarks'
+      expect(page).to have_content 'Bookmark'
+    end
+  end
+
+  it 'cites items in current bookmarks page' do
+    VCR.use_cassette('item_result') do
+      visit 'catalog/1001523' # Shakespeare : a historical and critical study with annotated texts of twenty-one plays
+      check 'Bookmark'
+    end
+
+    VCR.use_cassette('item to bookmark') do
+      visit 'catalog/1002481' # Shakespeare at the Globe : 1599-1609 / Bernard Beckerman
+      check 'Bookmark'
+    end
+
+    visit '/bookmarks?per_page=1'
+    expect(page).to have_content 'Shakespeare at the Globe'
+    expect(page).not_to have_content 'Shakespeare : a historical and critical study with annotated texts of twenty-one plays'
+  end
+end

--- a/spec/fixtures/vcr_cassettes/item_to_bookmark.yml
+++ b/spec/fixtures/vcr_cassettes/item_to_bookmark.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ws.library.ualberta.ca/symws3/rest/standard/lookupTitleInfo?clientID=Primo&includeAvailabilityInfo=true&includeItemInfo=true&includeMarcHoldings=true&marcEntryFilter=ALL&titleID=1002481
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 29 Mar 2019 16:20:26 GMT
+      Server:
+      - Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><LookupTitleInfoResponse
+        xmlns="http://schemas.sirsidynix.com/symws/standard"><TitleInfo><titleID>1002481</titleID><TitleAvailabilityInfo><totalCopiesAvailable>7</totalCopiesAvailable><libraryWithAvailableCopies>Burman
+        University</libraryWithAvailableCopies><libraryWithAvailableCopies>University
+        of Alberta Rutherford-Humanities &amp; Social Science</libraryWithAvailableCopies><libraryWithAvailableCopies>Vanguard
+        College</libraryWithAvailableCopies><totalResvCopiesAvailable>0</totalResvCopiesAvailable><locationOfFirstAvailableItem>ON_SHELF</locationOfFirstAvailableItem><holdable>true</holdable><bookable>false</bookable></TitleAvailabilityInfo><CallInfo><libraryID>BURMAN</libraryID><classificationID>LC</classificationID><callNumber>PR
+        3095 .B4 1966</callNumber><numberOfCopies>1</numberOfCopies><ItemInfo><itemID>32860000453984</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><CallInfo><libraryID>UAHSS</libraryID><classificationID>LC</classificationID><callNumber>PR
+        3095 B39 1966</callNumber><numberOfCopies>5</numberOfCopies><ItemInfo><itemID>0162001016151</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo><ItemInfo><itemID>000024114811</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo><ItemInfo><itemID>000024114829</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo><ItemInfo><itemID>000024114837</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo><ItemInfo><itemID>000024114845</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><CallInfo><libraryID>VANGUARD</libraryID><classificationID>LC</classificationID><callNumber>PR
+        3095 B4 1966</callNumber><numberOfCopies>1</numberOfCopies><ItemInfo><itemID>0163900164134</itemID><itemTypeID>BOOK</itemTypeID><currentLocationID>ON_SHELF</currentLocationID><homeLocationID>ON_SHELF</homeLocationID><chargeable>true</chargeable><fixedTimeBooking>false</fixedTimeBooking></ItemInfo></CallInfo><BibliographicInfo><MarcEntryInfo><label>Leader</label><entryID>000</entryID><indicators>  </indicators><text>am1
+        0c a</text></MarcEntryInfo><MarcEntryInfo><label>key</label><entryID>001</entryID><indicators>  </indicators><text>1002481</text></MarcEntryInfo><MarcEntryInfo><label>Fixed
+        field data</label><entryID>008</entryID><indicators>  </indicators><text>880413t19661962nyu    g          0
+        eng d</text></MarcEntryInfo><MarcEntryInfo><label>LCCN</label><entryID>010</entryID><indicators>  </indicators><text>62007159
+        /L</text></MarcEntryInfo><MarcEntryInfo><label>Local system #</label><entryID>035</entryID><indicators>  </indicators><text>ocm05019600</text></MarcEntryInfo><MarcEntryInfo><label>Cataloging
+        Source</label><entryID>040</entryID><indicators>  </indicators><text>LC eng</text></MarcEntryInfo><MarcEntryInfo><label>Geographic
+        Area Code</label><entryID>043</entryID><indicators>  </indicators><text>e-uk-en</text></MarcEntryInfo><MarcEntryInfo><label>Content
+        time period</label><entryID>045</entryID><indicators>  </indicators><text>t9u0</text></MarcEntryInfo><MarcEntryInfo><label>Local
+        holdings</label><entryID>049</entryID><indicators>  </indicators><text>AEU
+        eng</text></MarcEntryInfo><MarcEntryInfo><label>LC Call Number</label><entryID>050</entryID><indicators>
+        0</indicators><text>PR3095 .B4</text></MarcEntryInfo><MarcEntryInfo><label>Dewey
+        Decimal Classification Number</label><entryID>082</entryID><indicators>  </indicators><text>792.094216</text></MarcEntryInfo><MarcEntryInfo><label>Local
+        LC call number</label><entryID>090</entryID><indicators>  </indicators><text>PR
+        3095 B4 1966 ACHCU</text><entryTypeCodes>L</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Local
+        LC call number</label><entryID>090</entryID><indicators>  </indicators><text>PR
+        3095 B4 1966 AENABC</text><entryTypeCodes>L</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Local
+        LC call number</label><entryID>090</entryID><indicators>0 </indicators><text>PR
+        3095 B39 1966</text><entryTypeCodes>L</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Personal
+        Author</label><entryID>100</entryID><indicators>1 </indicators><text>Beckerman,
+        Bernard.</text><entryTypeCodes>MAR</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Title</label><entryID>245</entryID><indicators>10</indicators><text>Shakespeare
+        at the Globe : 1599-1609 / Bernard Beckerman.</text><entryTypeCodes>RMT</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Publication
+        info</label><entryID>260</entryID><indicators>  </indicators><text>New York
+        : Collier Books, 1966, c1962.</text><entryTypeCodes>Y</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Physical
+        description</label><entryID>300</entryID><indicators>  </indicators><text>254
+        p. ; 22 cm.</text></MarcEntryInfo><MarcEntryInfo><label>Content type</label><entryID>336</entryID><indicators>  </indicators><text>text
+        txt</text></MarcEntryInfo><MarcEntryInfo><label>Media type</label><entryID>337</entryID><indicators>  </indicators><text>unmediated
+        n</text></MarcEntryInfo><MarcEntryInfo><label>Carrier type</label><entryID>338</entryID><indicators>  </indicators><text>volume
+        nc</text></MarcEntryInfo><MarcEntryInfo><label>Held by</label><entryID>596</entryID><indicators>  </indicators><text>BURMAN
+        UAHSS VANGUARD</text><entryTypeCodes>H</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Personal
+        subject</label><entryID>600</entryID><indicators>10</indicators><text>Shakespeare,
+        William, 1564-1616--Stage history--To 1625.</text><entryTypeCodes>RS</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Personal
+        subject</label><entryID>600</entryID><indicators>10</indicators><text>Shakespeare,
+        William, 1564-1616--Technique.</text><entryTypeCodes>RS</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Personal
+        subject</label><entryID>600</entryID><indicators>10</indicators><text>Shakespeare,
+        William, 1564-1616--Dramatic production.</text><entryTypeCodes>RS</entryTypeCodes></MarcEntryInfo><MarcEntryInfo><label>Corporate
+        subject</label><entryID>610</entryID><indicators>20</indicators><text>Globe
+        Theatre (London, England : 1599-1644)</text><entryTypeCodes>RS</entryTypeCodes></MarcEntryInfo></BibliographicInfo></TitleInfo></LookupTitleInfoResponse>'
+    http_version: 
+  recorded_at: Fri, 29 Mar 2019 16:20:26 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Monkey patch BookmarksController#export_secret_token to use 
AS::KeyGenerator and set a 32 bit key

Also add some bookmark feature tests so that we can catch regressions of 
this feature.

Before:
```
ArgumentError: key must be 32 bytes
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/message_encryptor.rb", line 79, in key=
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/message_encryptor.rb", line 79, in _encrypt
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/message_encryptor.rb", line 60, in encrypt_and_sign
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/blacklight-5.15.0/lib/blacklight/token_based_user.rb", line 40, in encrypt_user_id
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/actionpack-4.2.11.1/lib/abstract_controller/helpers.rb", line 67, in encrypt_user_id
  File "/var/www/sites/blacklight/vendor/ruby/2.5.0/gems/blacklight-5.15.0/app/helpers/blacklight/url_helper_behavior.rb", line 298, in bookmarks_export_url
  File "/var/www/sites/blacklight/app/views/bookmarks/_refworks.html.erb", line 3, in _app_views_bookmarks__refworks_html_erb___1964368731853966007_70099749963600
  
```
then
![Screenshot from 2019-03-29 12-34-10](https://user-images.githubusercontent.com/1220762/55254982-f7b76a80-521e-11e9-800f-0fc502c9ebcb.png)

After:
![Screenshot from 2019-03-29 12-32-55](https://user-images.githubusercontent.com/1220762/55254947-e0787d00-521e-11e9-965d-1450deddaba4.png)
