### PR TITLE
chromedriver-helper is deprecated after 2019-03-31.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,5 @@ group :test do
   gem 'webmock', require: false
 
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     autoprefixer-rails (9.4.10.1)
@@ -99,9 +97,6 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -140,7 +135,6 @@ GEM
     html_tokenizer (0.0.7)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -180,6 +174,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.13.1)
     mysql2 (0.4.10)
+    net_http_ssl_fix (0.0.10)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     om (3.1.1)
@@ -341,6 +336,11 @@ GEM
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
+    webdrivers (3.7.1)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -364,7 +364,6 @@ DEPENDENCIES
   bootstrap_form (~> 2.7.0)
   brakeman
   capybara
-  chromedriver-helper
   devise
   devise-guests
   erb_lint (~> 0.0.28)
@@ -393,6 +392,7 @@ DEPENDENCIES
   turbolinks (= 5.2.0)
   uglifier (>= 1.3.0)
   vcr
+  webdrivers
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
Please update to use the 'webdrivers' gem instead.
See flavorjones/chromedriver-helper#83

resolves #1569 