### PR TITLE
fix grabBag tests after bootstrap refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- failing grabBag test for number of libraries displayed on the advanced search page after bootstrap refactor [PR#1701](https://github.com/ualbertalib/discovery/pull/1701)
+
 ## [3.0.107] - 2019-07-09
 
 ### Added

--- a/test/grabBag/t/libraryLocationsRegression.t
+++ b/test/grabBag/t/libraryLocationsRegression.t
@@ -35,7 +35,7 @@ unlike  ($result->decoded_content, qr/We are sorry, something has gone wrong/, "
 
 # We want to count Library locations to make sure that they are all there
 my $tree = HTML::TreeBuilder->new_from_content( $result->decoded_content ) ;
-my $libraries = $tree->findnodes( '/html/body/div[1]/div[6]/div[2]/div/div/div[1]/form/div/div[3]/div/div/div[3]/div[2]/div/ul/li' );
+my $libraries = $tree->findnodes( '/html/body/div[1]/div[5]/div[2]/div/div/div[1]/form/div/div[3]/div/div/div[3]/div/div/ul/li' );
 my $num_libraries = $libraries->size() ;
 ok ($libraries->size() > 50, "Count of libraries $num_libraries"); $count++;	# 54 on Sept 13, 2018, 53 on Dec 5, 2018 but this may change over time
 $tree->delete;


### PR DESCRIPTION
Xpath of 'Library' on the advanced search page changed with bootstrap refactor.

Should resolve http://cardiff.library.ualberta.ca/job/discovery-grabBag/1473/console