### PR TITLE
set default url as search.library.ualberta.ca in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## Changed
 - Made BPSC and RCRF forms redirect to the referring item page [#1443](https://github.com/ualbertalib/discovery/issues/1443)
+- production config change! updated to set default url as search.library.ualberta.ca related to refworks export from bookmarks [#1484](https://github.com/ualbertalib/discovery/issues/1484)
 
 ### Added
 - Added feature tests for item author links [#1710](https://github.com/ualbertalib/discovery/issues/1710)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.default_url_options = { host: 'library.ualberta.ca', port: 443, protocol: 'https' }
+Rails.application.routes.default_url_options = { host: 'search.library.ualberta.ca', port: 443, protocol: 'https' }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
related to refworks export from bookmarks #1484 

potentially related to why analytics not being collected #1516

I imagine that this was missed when the cms/discovery moved domains.