### PR TITLE
prepare for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.0.111] - 2019-10-23
+
 ### Changed
 - create migration which will change db/table/col to utf8mb4 encoding [PR#1801](https://github.com/ualbertalib/discovery/pull/1801)
 


### PR DESCRIPTION
The main purpose of this release is to fix the state of any related databases so that they use a consistent char set and collation.  This should workaround the problem experienced by the 3.0.110 release in staging.