### PR TITLE
Add version file and meta generator tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Added
+- Add version file and meta generator tag [#1343](https://github.com/ualbertalib/discovery/issues/1343)
+
 ### Changed
 - create migration which will change db/table/col to utf8mb4 encoding [PR#1801](https://github.com/ualbertalib/discovery/pull/1801)
 - re-dockerize to use modern ruby docker image and puma [PR#1805](https://github.com/ualbertalib/discovery/pull/1805)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
 
     <title>University of Alberta Libraries</title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
+    <meta name="generator" content="<%= "Discovery #{Discovery::VERSION} - https://github.com/ualbertalib/discovery" %>">
     <%# favicon_link_tag asset_path('favicon.ico') %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag 'application', 'https://fonts.googleapis.com/css?family=Open+Sans:400,700,400italic|Abel', media: 'all' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,9 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
+
+  VERSION = '3.0.11'.freeze # used in application layout meta generator tag
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
@@ -31,4 +34,5 @@ module Discovery
     config.symphony_timeout = 4
     config.sfx_timeout = 4
   end
+
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-
   VERSION = '3.0.11'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
@@ -34,5 +33,4 @@ module Discovery
     config.symphony_timeout = 4
     config.sfx_timeout = 4
   end
-
 end


### PR DESCRIPTION
It's hard to know which version of the code you're looking at.
If we can keep this up-to-date in our release management then we'll be
able to tell which version we see deployed by checking the page source.

![Screenshot from 2019-10-22 10-33-47](https://user-images.githubusercontent.com/1220762/67309928-01096c80-f4ba-11e9-8733-1066e399cf8b.png)


fixes #1343