### PR TITLE
add bundler build config to make sassc gem portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ## [3.0.111] - 2019-10-23
 
 ### Changed
+- for Docker add bundler build config to make sassc gem portable [PR]()
+
+## [3.0.111] - 2019-10-23
+
+### Changed
 - create migration which will change db/table/col to utf8mb4 encoding [PR#1801](https://github.com/ualbertalib/discovery/pull/1801)
 - re-dockerize to use modern ruby docker image and puma [PR#1805](https://github.com/ualbertalib/discovery/pull/1805)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
-## [3.0.111] - 2019-10-23
-
 ### Changed
-- for Docker add bundler build config to make sassc gem portable [PR]()
+- for Docker add bundler build config to make sassc gem portable [#1796](https://github.com/ualbertalib/discovery/issues/1796)
 
 ## [3.0.111] - 2019-10-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR $APP_ROOT
 # Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
 COPY Gemfile  $APP_ROOT
 COPY Gemfile.lock $APP_ROOT
+RUN bundle config --local build.sassc --disable-march-tune-native
 RUN bundle install --without development test --jobs=3 --retry=3
 
 # *NOW* we copy the codebase in


### PR DESCRIPTION
was finding that images built on docker hub and used on our architecture
would fail with illegal instrucation.  This workaround described
https://github.com/sass/sassc-ruby/issues/146#issuecomment-534197168
will make the prebuild gem portable.

#1796 