### PR TITLE
Fix errors in Holdings Helper that are causing issues in the most recent deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- missing variable declaration in Location error handling [#1824](https://github.com/ualbertalib/discovery/issues/1824)
+
 ### Changed
 - updated occurences of University of Alberta Libraries to Library (new name) [#1813](https://github.com/ualbertalib/discovery/issues/1813)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Fixed
 - missing variable declaration in Location error handling [#1824](https://github.com/ualbertalib/discovery/issues/1824)
+- typo of CirculationRule in Holdings Helper [#1823](https://github.com/ualbertalib/discovery/issues/1823)
 
 ### Changed
 - updated occurences of University of Alberta Libraries to Library (new name) [#1813](https://github.com/ualbertalib/discovery/issues/1813)

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -70,7 +70,7 @@ module HoldingsHelper
   # returns the library description that matches the code coming from symphony ws
   def library_location(library_code)
     Location.find_by!(short_code: library_code.downcase.delete('_').to_sym).name
-  rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for Location #{library_code.downcase.delete('_').to_sym}", e)
     'Unknown'
   end

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -31,9 +31,9 @@ module HoldingsHelper
   end
 
   def reserve_rule(item)
-    CirculationRules.find_by!(short_code: item[:reserve_rule].to_sym).name
+    CirculationRule.find_by!(short_code: item[:reserve_rule].to_sym).name
   rescue ActiveRecord::RecordNotFound => e
-    Rollbar.error("Error retriving name for CirculationRules #{item[:reserve_rule].to_sym}", e)
+    Rollbar.error("Error retriving name for CirculationRule #{item[:reserve_rule].to_sym}", e)
     'Unknown'
   end
 


### PR DESCRIPTION
#1824 Is a missed variable declaration in Location error handling

#1823 Is a typo where CirculationRules was called instead of CirculationRule
