### PR TITLE
bump version for 3.0.113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.0.113] - 2019-11-01
+
 ### Fixed
 - missing variable declaration in Location error handling [#1824](https://github.com/ualbertalib/discovery/issues/1824)
 - typo of CirculationRule in Holdings Helper [#1823](https://github.com/ualbertalib/discovery/issues/1823)

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.0.112'.freeze # used in application layout meta generator tag
+  VERSION = '3.0.113'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
A release was cut without bumping the version number.