### PR TITLE
use safe operator on empty location_tesim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- searches failing with no location_tesim [#1811](https://github.com/ualbertalib/discovery/issues/1811)
+
 ## [3.0.113] - 2019-11-01
 
 ### Fixed

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -19,7 +19,7 @@
           <div class="row">
             <dt class="blacklight-format col-md-3">Copies owned by: </dt>
             <dd class="blacklight-format col-md-9">
-              <%= document['location_tesim'].join(', ') %>
+              <%= document['location_tesim']&.join(', ') %>
         <% end %>
         <% if libguides_icons(document).each do |icon| -%>
           <%= link_to icon[:url] do %>


### PR DESCRIPTION
Searches that contain results with empty `location_tesim` were failing
since September 11, 2019 at ~9:30am.  There was a re-index shortly before
that date but not a direct correlation. The cause at this time and
any other implications is unknown.

location_tesim is used to show the item's copies owned by. It also is a
facet and used to detect if the UAL shield should be shown.

#1811 