### PR TITLE
create an 'Unknown' entry for ActiveRecord::RecordNotFound events to limit Rollbar errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Changed
+- create an 'Unknown' entry for ActiveRecord::RecordNotFound events to limit Rollbar errors [#1853](https://github.com/ualbertalib/discovery/issues/1853)
+
 ### Fixed
 - searches failing with no location_tesim [#1811](https://github.com/ualbertalib/discovery/issues/1811)
 

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -20,6 +20,7 @@ module HoldingsHelper
     Status.find_by!(short_code: item[:status].downcase.underscore).name
   rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for Status #{item[:status].downcase.underscore}", e)
+    Status.create(short_code: item[:status].downcase.underscore, name: 'Unknown')
     'Unknown'
   end
 
@@ -27,6 +28,7 @@ module HoldingsHelper
     ItemType.find_by!(short_code: item[:type].downcase.to_sym).name
   rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for ItemType #{item[:type].downcase.to_sym}", e)
+    ItemType.create(short_code: item[:type].downcase.to_sym, name: 'Unknown')
     'Unknown'
   end
 
@@ -34,6 +36,7 @@ module HoldingsHelper
     CirculationRule.find_by!(short_code: item[:reserve_rule].to_sym).name
   rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for CirculationRule #{item[:reserve_rule].to_sym}", e)
+    CirculationRule.create(short_code: item[:reserve_rule].to_sym, name: 'Unknown')
     'Unknown'
   end
 
@@ -72,6 +75,10 @@ module HoldingsHelper
     Location.find_by!(short_code: library_code.downcase.delete('_').to_sym).name
   rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for Location #{library_code.downcase.delete('_').to_sym}", e)
+    Location.create(
+        short_code: library_code.downcase.delete('_').to_sym,
+        name: 'Unknown'
+    )
     'Unknown'
   end
 

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -76,8 +76,8 @@ module HoldingsHelper
   rescue ActiveRecord::RecordNotFound => e
     Rollbar.error("Error retriving name for Location #{library_code.downcase.delete('_').to_sym}", e)
     Location.create(
-        short_code: library_code.downcase.delete('_').to_sym,
-        name: 'Unknown'
+      short_code: library_code.downcase.delete('_').to_sym,
+      name: 'Unknown'
     )
     'Unknown'
   end


### PR DESCRIPTION
It's taken more time that expected to resolve these and are triggering
many Rollbar Events ($$$).

#1853 