### PR TITLE
change data sanity regression test values for databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ### Removed
 - update tests to address deprecations [PR#1901](https://github.com/ualbertalib/discovery/pull/1901)
 
+### Changed
+- data sanity regression test values for databases [PR#]()
+
 ## [3.0.116] - 2020-02-02
 ### Added
 - Added "See License Terms" link to SFX e-journal record holdings. [#1893]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 - update tests to address deprecations [PR#1901](https://github.com/ualbertalib/discovery/pull/1901)
 
 ### Changed
-- data sanity regression test values for databases [PR#]()
+- data sanity regression test values for databases [PR#1915](https://github.com/ualbertalib/discovery/pull/1915)
 
 ## [3.0.116] - 2020-02-02
 ### Added

--- a/test/grabBag/t/dataSanityRegression.t
+++ b/test/grabBag/t/dataSanityRegression.t
@@ -42,11 +42,11 @@ my @collections = (
   },
   {
     name	=>  'journals',
-    minimum	=>  10
+    minimum	=>  1
   },
   {
     name	=>  'databases',
-    minimum	=>  10
+    minimum	=>  1
   }
 );
 for my $href (@collections) {


### PR DESCRIPTION
In response to the UCP government budget for post-secondary universities
and how it was passed down to the library, we've implemented cuts to
our collections resulting in fewer databases. The tests should reflect this.