### PR TITLE
use memoization to protect against N+1 query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 - create backup tables for library and location [#1843](https://github.com/ualbertalib/discovery/issues/1843)
 - add symphony_nightly generator [#1843](https://github.com/ualbertalib/discovery/issues/1843)
 
+### Fixed
+- N+1 query memoized for location, status, item type and circulation rules [PR#1937](https://github.com/ualbertalib/discovery/pull/1937)
+
 ## [3.0.116] - 2020-02-02
 
 ### Added


### PR DESCRIPTION
Was doing a database lookup for each holding of an item.  Where the item
has volumes upon volumes like catalog/1772030 this is very inefficient.

The solution incorporates memoization using `Hash.new` initializer to call a block only if the entry doesn't already
exist (https://www.justinweiss.com/articles/4-simple-memoization-patterns-in-ruby-and-one-gem/#and-what-about-parameters?)

I was worried that instance variables (@Locations) would have a cache invalidation
problem, but found out that there is a seperate controller instance for
each web request so this isn't really an issue.