### PR TITLE
remove danger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ bundler_args: --without development production --jobs=3 --retry=3
 services:
   - mysql
 before_script:
-  - bundle exec danger
   - docker version
   - docker-compose version
 


### PR DESCRIPTION
Found that travis was exposing danger token.  We changed the token and the CI for jupiter.  Just going to remove danger here.