### PR TITLE
bump for 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.1.0] - 2020-04-06
+
 ### Removed
 - update tests to address deprecations [PR#1901](https://github.com/ualbertalib/discovery/pull/1901)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.0.116'.freeze # used in application layout meta generator tag
+  VERSION = '3.1.0'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
I chose a minor release because of the added symphony_nightly generator. Probably should have triggered this earlier with some previous changes.

This is a local branch now rather than from my fork so that travis will be okay with our danger key.