### PR TITLE
abort `symphony_nightly` if data files do not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- abort `symphony_nightly` if data files do not exist. [PR#]()
+
 ## [3.1.0] - 2020-04-06
 
 ### Removed

--- a/lib/generators/symphony_nightly/symphony_nightly_generator.rb
+++ b/lib/generators/symphony_nightly/symphony_nightly_generator.rb
@@ -4,12 +4,18 @@ class SymphonyNightlyGenerator < Rails::Generators::Base
   desc "Creates a new database migration from the current symphony config
   data dump found at `data/data4discovery`"
 
+  HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE = 'data/data4discovery.txt'.freeze
+  HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE = 'data/Data4DiscoveryManual.txt'.freeze
+
   def self.next_migration_number(path)
     next_migration_number = current_migration_number(path) + 1
     ActiveRecord::Migration.next_migration_number(next_migration_number)
   end
 
   def copy_migrations
+    abort "#{HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE} is missing." unless File.exist?(HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE)
+    abort "#{HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE} is missing." unless File.exist?(HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE)
+
     # in order to create a new migration every night we need to make the migration
     # unique.  Here we append today's date.
     migration_template 'update_symphony_nightly.erb',


### PR DESCRIPTION
Also considered `warn  "#{HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE} is getting stale" unless  File.mtime(HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE) > 24.hours.ago` to check if the file is recent.  I'm not sure if this is helpful at this point so I'll wait for feedback.

#1843

## What's New

Instead of exiting with `No such file or directory @ rb_sysopen - data/data4discovery.txt (Errno::ENOENT)` will abort with exit code 1 and the stderr message "<file> is missing."
