### PR TITLE
abort `symphony_nightly` if data files do not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- abort `symphony_nightly` if data files do not exist. [PR#]()
+
 ## [3.1.0] - 2020-04-06
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ## [Unreleased]
 
 ### Fixed
-- abort `symphony_nightly` if data files do not exist. [PR#]()
+- abort `symphony_nightly` if data files do not exist. [PR#1961](https://github.com/ualbertalib/discovery/pull/1961)
 
 ## [3.1.0] - 2020-04-06
 

--- a/lib/generators/symphony_nightly/symphony_nightly_generator.rb
+++ b/lib/generators/symphony_nightly/symphony_nightly_generator.rb
@@ -4,12 +4,18 @@ class SymphonyNightlyGenerator < Rails::Generators::Base
   desc "Creates a new database migration from the current symphony config
   data dump found at `data/data4discovery`"
 
+  HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE = 'data/data4discovery.txt'.freeze
+  HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE = 'data/Data4DiscoveryManual.txt'.freeze
+
   def self.next_migration_number(path)
     next_migration_number = current_migration_number(path) + 1
     ActiveRecord::Migration.next_migration_number(next_migration_number)
   end
 
   def copy_migrations
+    abort "#{HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE} is missing." unless File.exist?(HUMAN_READBLE_STRINGS_FROM_SYMPHONY_FILE)
+    abort "#{HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE} is missing." unless File.exist?(HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE)
+
     # in order to create a new migration every night we need to make the migration
     # unique.  Here we append today's date.
     migration_template 'update_symphony_nightly.erb',


### PR DESCRIPTION
In a recent email @nmacgreg was concerned about how this should handle exceptions.  I wrote, 
> First, something (cron) or someone must invoke `rails g[enerate] symphony_nightly` (where the 'enerate' is optional). This reads the two files in the data directory and creates a database migration with the timestamp of today's date. That's it, that's all that task does.  If the file/files don't exist it will terminate in error (No such file or directory @ rb_sysopen - data/data4discovery.txt (Errno::ENOENT)) and create an empty migration file (in db/migrate). It will not check if the file has changed from any previous state or inspect a timestamp. If you try to run the same generator on the same calendar day it will fail with the message:
    conflict  db/migrate/20200415200531_update_symphony_nightly_20200415.rb
Another migration is already named update_symphony_nightly_20200415: <your path>/db/migrate/20200415195319_update_symphony_nightly_20200415.rb. Use --force to replace this migration or --skip to ignore conflicted file.
As mentioned you could use --force to replace the migration or delete the file then try again.

> After writing it out I can see that having the empty migration lying around is asking for trouble.  I can make an adjustment so that the task will fail in error and not create a file.  Any suggestions on what the error message should contain? Should I also make an adjustment to inspect the file's timestamp and make a decision of whether or not to build a migration?  Say it must be current in the last 25 hours?

I also considered `warn  "#{HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE} is getting stale" unless  File.mtime(HUMAN_READABLE_STRINGS_FROM_EZPROXY_FILE) > 24.hours.ago` to check if the file is recent.  I'm not sure if this is helpful at this point so I'll wait for feedback.

#1843

## What's New

Instead of exiting with `No such file or directory @ rb_sysopen - data/data4discovery.txt (Errno::ENOENT)` will abort with exit code 1 and the stderr message "\<file\> is missing."
