### PR TITLE
remove calls to error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- removed reference to error variable in Rollbar errors [PR#1962](https://github.com/ualbertalib/discovery/pull/1962)
+
 ## [3.1.0] - 2020-04-06
 
 ### Removed

--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -19,7 +19,7 @@ module HoldingsHelper
   def symphony_status(item)
     @symphony_status ||= Hash.new do |h, key|
       status = Status.find_by(short_code: key) || begin
-        Rollbar.error("Error retriving name for Status #{key}", e)
+        Rollbar.error("Error retriving name for Status #{key}")
         Status.create(short_code: key, name: 'Unknown')
       end
       h[key] = status.name
@@ -30,7 +30,7 @@ module HoldingsHelper
   def item_type(item)
     @item_type ||= Hash.new do |h, key|
       type = ItemType.find_by(short_code: key) || begin
-        Rollbar.error("Error retriving name for ItemType #{key}", e)
+        Rollbar.error("Error retriving name for ItemType #{key}")
         ItemType.create(short_code: key, name: 'Unknown')
       end
       h[key] = type.name
@@ -41,7 +41,7 @@ module HoldingsHelper
   def reserve_rule(item)
     @reserve_rule ||= Hash.new do |h, key|
       rule = CirculationRule.find_by(short_code: key) || begin
-        Rollbar.error("Error retriving name for CirculationRule #{key}", e)
+        Rollbar.error("Error retriving name for CirculationRule #{key}")
         CirculationRule.create(short_code: key, name: 'Unknown')
       end
       h[key] = rule.name
@@ -83,7 +83,7 @@ module HoldingsHelper
   def library_location(library_code)
     @location_name ||= Hash.new do |h, key|
       location = Location.includes(:library).find_by(short_code: key) || begin
-        Rollbar.error("Error retriving name for Location #{key}", e)
+        Rollbar.error("Error retriving name for Location #{key}")
         Location.create(
           short_code: key,
           name: 'Unknown'


### PR DESCRIPTION
## Context

When I added memoization to protect against an N+1 query I left the e Error variable behind.

Related to https://github.com/ualbertalib/discovery/commit/ee295932dfd58c7275b68e6d0b5052215c09d115