### PR TITLE
add solr_marc_prep generator consumed by the ingest rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Added
+- add generator to prep files for SolrMarc before ingest [#1939](https://github.com/ualbertalib/discovery/issues/1939)
+
 ### Fixed
 - abort `symphony_nightly` if data files do not exist. [PR#1961](https://github.com/ualbertalib/discovery/pull/1961)
 - removed reference to error variable in Rollbar errors [PR#1962](https://github.com/ualbertalib/discovery/pull/1962)

--- a/db/migrate/20200319205106_add_symphony_id_to_location.rb
+++ b/db/migrate/20200319205106_add_symphony_id_to_location.rb
@@ -1,0 +1,78 @@
+class AddSymphonyIdToLocation < ActiveRecord::Migration
+  CODES = {
+    'AGINTERNET' => 1,
+    'AGL_CAP' => 2,
+    'NORQ_MAIN' => 3,
+    'AHS_RVGH' => 4,
+    'NORQ_WEST' => 5,
+    'CONCORD_IN' => 6,
+    'AHS_KEC' => 7,
+    'KEYANO' => 8,
+    'NLC_GR' => 9,
+    'AHS_TBCC' => 10,
+    'NLC_INT' => 11,
+    'AITF_C-FER' => 12,
+    'NEOS_FREE' => 13,
+    'AITF_MW' => 14,
+    'AITF_VEG' => 15,
+    'UAAUG' => 16,
+    'COVENANTGN' => 17,
+    'COVENANTMH' => 18,
+    'AHSGLENRSE' => 20,
+    'CONCORDIA' => 21,
+    'NLC_SL' => 22,
+    'BURMAN' => 23,
+    'GR_MAC_TSV' => 24,
+    'AHS_INT' => 27,
+    'GPRC_GP' => 28,
+    'GR_MACEWAN' => 29,
+    'KINGS' => 31,
+    'NEWMAN' => 32,
+    'OLDS' => 33,
+    'CONCORDSEM' => 34,
+    'RED_DEER_C' => 35,
+    'TAYLOR' => 36,
+    'UAARCHIVES' => 37,
+    'UARCRF' => 38,
+    'UABSJ' => 39,
+    'UABUSINESS' => 40,
+    'UAEDUC' => 41,
+    'UAHLTHSC' => 42,
+    'UAHSS' => 43,
+    'UAINTERNET' => 44,
+    'UALAW' => 45,
+    'UAMATH' => 46,
+    'AHS_REDDR' => 47,
+    'UASCITECH' => 48,
+    'UASJC' => 49,
+    'UASPCOLL' => 50,
+    'UATECHSERV' => 51,
+    'LAKELND_LL' => 52,
+    'LAKELND_VR' => 53,
+    'GPRC_FRVW' => 54,
+    'GR_MAC_ACC' => 55,
+    'GR_MAC_INT' => 57,
+    'AHS_ACH' => 58,
+    'VANGUARD' => 59,
+    'GPRC_INT' => 60,
+    'LAKELND_IN' => 61
+  }.freeze
+
+  def up
+    # the Symphony id is used by SolrMarc to map from 596a to Institution
+    add_column :locations, :symphony_id, :integer, default: nil
+
+    Location.reset_column_information
+
+    CODES.each do |short_code, symphony_id|
+      entry = Location.find_or_initialize_by(short_code: short_code)
+      entry.symphony_id = symphony_id
+      entry.save
+    end
+    
+  end
+
+  def down
+    remove_column :locations, :symphony_id
+  end
+end

--- a/db/migrate/20200319205106_add_symphony_id_to_location.rb
+++ b/db/migrate/20200319205106_add_symphony_id_to_location.rb
@@ -69,6 +69,9 @@ class AddSymphonyIdToLocation < ActiveRecord::Migration
       entry.symphony_id = symphony_id
       entry.save
     end
+
+    # missed this previously
+    Location.create(short_code: 'bmufa', name: "Kule Collection")
     
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200128220027) do
+ActiveRecord::Schema.define(version: 20200319205106) do
 
   create_table "backup_libraries", force: :cascade do |t|
     t.string   "short_code", limit: 255
@@ -71,12 +71,13 @@ ActiveRecord::Schema.define(version: 20200128220027) do
   end
 
   create_table "locations", force: :cascade do |t|
-    t.string   "short_code", limit: 255
-    t.string   "name",       limit: 255
-    t.string   "url",        limit: 255
-    t.integer  "library_id", limit: 4
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.string   "short_code",  limit: 255
+    t.string   "name",        limit: 255
+    t.string   "url",         limit: 255
+    t.integer  "library_id",  limit: 4
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+    t.integer  "symphony_id", limit: 4
   end
 
   add_index "locations", ["library_id"], name: "index_locations_on_library_id", using: :btree

--- a/lib/generators/solr_marc_prep/USAGE
+++ b/lib/generators/solr_marc_prep/USAGE
@@ -1,0 +1,10 @@
+Description:
+    Replaces maps used by the ingest process.  In particular these provide the human readable string for locations
+    and institutions based on the latest values in the application database.
+
+Example:
+    rails generate solr_marc_prep
+
+    This will replace:
+        config/SolrMarc/index_scripts/institution.bsh
+        config/SolrMarc/index_scripts/location_facet.bsh

--- a/lib/generators/solr_marc_prep/solr_marc_prep_generator.rb
+++ b/lib/generators/solr_marc_prep/solr_marc_prep_generator.rb
@@ -1,0 +1,11 @@
+class SolrMarcPrepGenerator < Rails::Generators::Base
+  source_root File.expand_path('templates', __dir__)
+
+  def copy_location_facet_for_solr_marc
+    template 'location_facet.bsh.erb', 'config/SolrMarc/index_scripts/location_facet.bsh', force: true
+  end
+
+  def copy_institution_for_solr_marc
+    template 'institution.bsh.erb', 'config/SolrMarc/index_scripts/institution.bsh', force: true
+  end
+end

--- a/lib/generators/solr_marc_prep/templates/institution.bsh.erb
+++ b/lib/generators/solr_marc_prep/templates/institution.bsh.erb
@@ -10,14 +10,13 @@ public Set getInstitutions(Record record){
   if (code_string != null){
   String[] codes = code_string.split(" ");
   Hashtable institution_codes = new Hashtable();
-
-  <%- Location.order(:symphony_id).each do |l| %>
-  <%-   if l.symphony_id.present? && l.library -%>
+  <% Location.includes(:library).order(:symphony_id).where.not(symphony_id: nil).each do |l| -%>
+  <%-   if l.library %>
   <%=     "institution_codes.put(\"#{l.symphony_id}\", \"#{l.library.name}\");" -%>
-  <%-   elsif l.symphony_id.present? -%>
+  <%-   else %>
   <%=     "institution_codes.put(\"#{l.symphony_id}\", \"#{l.name}\");" -%>
   <%-   end -%>
-  <%- end -%>
+  <%- end %>
 
  for (String code : codes){
     institutions.add(institution_codes.get(code));

--- a/lib/generators/solr_marc_prep/templates/institution.bsh.erb
+++ b/lib/generators/solr_marc_prep/templates/institution.bsh.erb
@@ -1,0 +1,27 @@
+import org.marc4j.marc.Record;
+
+org.solrmarc.index.SolrIndexer indexer = null;
+
+public Set getInstitutions(Record record){
+
+  Set institutions = new LinkedHashSet();
+  String code_string = indexer.getFirstFieldVal(record, "596a");
+
+  if (code_string != null){
+  String[] codes = code_string.split(" ");
+  Hashtable institution_codes = new Hashtable();
+
+  <%- Location.order(:symphony_id).each do |l| %>
+  <%-   if l.symphony_id.present? && l.library -%>
+  <%=     "institution_codes.put(\"#{l.symphony_id}\", \"#{l.library.name}\");" -%>
+  <%-   elsif l.symphony_id.present? -%>
+  <%=     "institution_codes.put(\"#{l.symphony_id}\", \"#{l.name}\");" -%>
+  <%-   end -%>
+  <%- end -%>
+
+ for (String code : codes){
+    institutions.add(institution_codes.get(code));
+  }
+}
+ return institutions;
+}

--- a/lib/generators/solr_marc_prep/templates/location_facet.bsh.erb
+++ b/lib/generators/solr_marc_prep/templates/location_facet.bsh.erb
@@ -8,7 +8,7 @@ public Set getLocationFacet(Record record){
   Set codes = indexer.getFieldList(record,"926m");
   Hashtable location_codes = new Hashtable();
   <% Location.order(:short_code).each do |l| %>
-    <%= "location_codes.put(\"#{l.short_code}\", \"#{l.name}\");" -%>
+  <%=  "location_codes.put(\"#{l.short_code}\", \"#{l.name}\");" -%>
   <% end %>
 
   for (String code : codes){

--- a/lib/generators/solr_marc_prep/templates/location_facet.bsh.erb
+++ b/lib/generators/solr_marc_prep/templates/location_facet.bsh.erb
@@ -1,0 +1,18 @@
+import org.marc4j.marc.Record;
+
+org.solrmarc.index.SolrIndexer indexer = null;
+
+public Set getLocationFacet(Record record){
+
+  Set locations = new LinkedHashSet();
+  Set codes = indexer.getFieldList(record,"926m");
+  Hashtable location_codes = new Hashtable();
+  <% Location.order(:short_code).each do |l| %>
+    <%= "location_codes.put(\"#{l.short_code}\", \"#{l.name}\");" -%>
+  <% end %>
+
+  for (String code : codes){
+    locations.add(location_codes.get(code));
+  }
+ return locations;
+}

--- a/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
+++ b/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
@@ -27,6 +27,7 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
     create_table_libraries
     create_table_locations
 
+    Location.create(short_code: 'bmufa', name: "Kule Collection")
     <%  CSV.foreach('data/data4discovery.txt', col_sep: '|') do |row| -%>
     <%-   case row[0]
           when 'CIRC' -%>CirculationRule.create(short_code: '<%= row[2] %>', name: "<%= row[11] %>")

--- a/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
+++ b/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
@@ -32,7 +32,7 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
           when 'CIRC' -%>CirculationRule.create(short_code: '<%= row[2] %>', name: "<%= row[11] %>")
     <%-   when 'ITYP' %>ItemType.create(short_code: '<%= row[2] %>', name: "<%= row[8] %>")
     <%-   when 'LOCN' %>Status.create(short_code: '<%= row[2] %>', name: "<%= row[6] %>")
-    <%-   when 'LIBR' %>Location.create(short_code: '<%= row[2] %>', name: "<%= row[21] %>")
+    <%-   when 'LIBR' %>Location.create(short_code: '<%= row[2] %>', symphony_id: '<%= row[1] %>', name: "<%= row[21] %>")
     <%-   end -%>
     <%  end -%>
     <%  CSV.foreach('data/Data4DiscoveryManual.txt', col_sep: '|') do |row| %>
@@ -71,6 +71,7 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
     end
     create_table :backup_locations do |t|
       t.string :short_code, null: false
+      t.integer :symphony_id
       t.string :name, null: false
       t.string :url
       t.references :backup_library, index: true, foreign_key: true
@@ -121,6 +122,7 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
   def create_table_locations
     create_table :locations do |t|
       t.string :short_code, null: false
+      t.integer :symphony_id
       t.string :name, null: false
       t.string :url
       t.references :library, index: true, foreign_key: true

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -26,8 +26,13 @@ task :ingest_info do
   puts "Solr collection contains #{response['response']['numFound']} results."
 end
 
+desc 'update maps for location facets from current db state'
+task :update_maps do
+  sh 'rails g solr_marc_prep'
+end
+
 desc 'ingest records' # add config parameter for directory ingest?
-task :ingest, [:collection] do |_t, args|
+task :ingest, [:collection] => [:update_maps] do |_t, args|
   log_config = YAML.load_file("#{Rails.root}/config/logger.yml")[Rails.env]
   log_file = if File.exist? log_config['log_path']
                File.open(log_config['log_path'], File::WRONLY | File::APPEND)

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -26,13 +26,13 @@ task :ingest_info do
   puts "Solr collection contains #{response['response']['numFound']} results."
 end
 
-desc 'update maps for location facets from current db state'
-task :update_maps do
+desc 'update Solr Marc maps for location facets from current database state'
+task :update_solr_marc_maps do
   sh 'rails g solr_marc_prep'
 end
 
 desc 'ingest records' # add config parameter for directory ingest?
-task :ingest, [:collection] => [:update_maps] do |_t, args|
+task :ingest, [:collection] => [:update_solr_marc_maps] do |_t, args|
   log_config = YAML.load_file("#{Rails.root}/config/logger.yml")[Rails.env]
   log_file = if File.exist? log_config['log_path']
                File.open(log_config['log_path'], File::WRONLY | File::APPEND)

--- a/spec/lib/generators/solr_marc_prep/solr_marc_prep_generator_test.rb
+++ b/spec/lib/generators/solr_marc_prep/solr_marc_prep_generator_test.rb
@@ -1,0 +1,21 @@
+require 'generator_spec/test_case'
+require 'generators/solr_marc_prep/solr_marc_prep_generator'
+
+describe SolrMarcPrepGenerator, type: :generator do
+  destination File.expand_path("../../tmp", __FILE__)
+
+  before(:all) do
+    prepare_destination
+    run_generator
+  end
+
+  it "creates a institutions beanshell mapping script" do
+    Location.create(short_code: 'UAINTERNET', symphony_id: '44', name: "University of Alberta Internet")
+    run_generator
+    assert_file "config/SolrMarc/index_scripts/institution.bsh", "institution_codes.put("44", "University of Alberta");"
+  end
+
+  it "creates a location facets beanshell mapping script" do
+    assert_file "config/SolrMarc/index_scripts/location_facet.bsh"
+  end
+end

--- a/spec/lib/generators/solr_marc_prep/solr_marc_prep_generator_test.rb
+++ b/spec/lib/generators/solr_marc_prep/solr_marc_prep_generator_test.rb
@@ -2,20 +2,20 @@ require 'generator_spec/test_case'
 require 'generators/solr_marc_prep/solr_marc_prep_generator'
 
 describe SolrMarcPrepGenerator, type: :generator do
-  destination File.expand_path("../../tmp", __FILE__)
+  destination File.expand_path('../tmp', __dir__)
 
   before(:all) do
     prepare_destination
     run_generator
   end
 
-  it "creates a institutions beanshell mapping script" do
-    Location.create(short_code: 'UAINTERNET', symphony_id: '44', name: "University of Alberta Internet")
+  it 'creates a institutions beanshell mapping script' do
+    Location.create(short_code: 'UAINTERNET', symphony_id: '44', name: 'University of Alberta Internet')
     run_generator
-    assert_file "config/SolrMarc/index_scripts/institution.bsh", "institution_codes.put("44", "University of Alberta");"
+    assert_file 'config/SolrMarc/index_scripts/institution.bsh', 'institution_codes.put("44", "University of Alberta");'
   end
 
-  it "creates a location facets beanshell mapping script" do
-    assert_file "config/SolrMarc/index_scripts/location_facet.bsh"
+  it 'creates a location facets beanshell mapping script' do
+    assert_file 'config/SolrMarc/index_scripts/location_facet.bsh'
   end
 end


### PR DESCRIPTION
Since release 3.0.113, we have moved the management of location codes,
circulation rules, statuses, and item types into DB, instead of static
yml file in Discovery. This will avoid a new release every time a change
is introduced in Symphony, and will allow for more efficient/accurate
data used in Discovery.

Now we need to use this same information when indexing/ingesting the
MARC data into Solr. When `rake ingest[collection]` is invoked, the
generator will be called which will use the current database values in
a template to replace two files that map to human readable strings for
Institution and Library in the application's facets.

#1939 