### PR TITLE
fix regression test after reskin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- regression test of library count on advanced search page after reskin changed layout
+
 ## [3.3.1] - 2020-06-23
 
 ### Changed

--- a/test/grabBag/t/libraryLocationsRegression.t
+++ b/test/grabBag/t/libraryLocationsRegression.t
@@ -35,7 +35,7 @@ unlike  ($result->decoded_content, qr/We are sorry, something has gone wrong/, "
 
 # We want to count Library locations to make sure that they are all there
 my $tree = HTML::TreeBuilder->new_from_content( $result->decoded_content ) ;
-my $libraries = $tree->findnodes( '/html/body/div[1]/div[5]/div[2]/div/div/div[1]/form/div/div[3]/div/div/div[3]/div/div/ul/li' );
+my $libraries = $tree->findnodes( '//form/div/div[3]/div/div/div[3]/div/div/ul/li' );
 my $num_libraries = $libraries->size() ;
 ok ($libraries->size() > 50, "Count of libraries $num_libraries"); $count++;	# 54 on Sept 13, 2018, 53 on Dec 5, 2018 but this may change over time
 $tree->delete;


### PR DESCRIPTION
The reskin simplified the layout and the path to the list of libraries on the advanced search changed.

This makes the test a little bit more robust by matching relative to the form  element