### PR TITLE
discourage holds placed on items with HathiTrust access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ## [Unreleased]
 
 ### Changed
-- discourage holds placed on items with HathiTrust access [#]()
+- discourage holds placed on items with HathiTrust access [#2003](https://github.com/ualbertalib/discovery/issues/2003)
 
 ### Fixed
 - regression test of library count on advanced search page after reskin changed layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Changed
+- discourage holds placed on items with HathiTrust access [#]()
+
 ### Fixed
 - regression test of library count on advanced search page after reskin changed layout
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,7 +61,7 @@ class CatalogController < ApplicationController
     @document.delete('publisher_tesim') if @document['published_display']
 
     @document['oclc'] = HathitrustOverlapRecord.find_by(catalog_id: @document['id'])&.oclc
-  
+
     # if we're able to provide this via HathiTrust agreement we should discourage anyone from tyring to place a hold
     @holdable = nil if @document['oclc']
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,7 +63,7 @@ class CatalogController < ApplicationController
     @document['oclc'] = HathitrustOverlapRecord.find_by(catalog_id: @document['id'])&.oclc
 
     # if we're able to provide this via HathiTrust agreement we should discourage anyone from tyring to place a hold
-    @holdable = nil if @document['oclc']
+    @holdable = nil if @document['oclc'].present?
   end
 
   configure_blacklight do |config|

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -62,7 +62,7 @@ class CatalogController < ApplicationController
 
     @document['oclc'] = HathitrustOverlapRecord.find_by(catalog_id: @document['id'])&.oclc
 
-    # if we're able to provide this via HathiTrust agreement we should discourage anyone from tyring to place a hold
+    # if we're able to provide this via HathiTrust agreement we should discourage anyone from trying to place a hold
     @holdable = nil if @document['oclc'].present?
   end
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -61,6 +61,9 @@ class CatalogController < ApplicationController
     @document.delete('publisher_tesim') if @document['published_display']
 
     @document['oclc'] = HathitrustOverlapRecord.find_by(catalog_id: @document['id'])&.oclc
+  
+    # if we're able to provide this via HathiTrust agreement we should discourage anyone from tyring to place a hold
+    @holdable = nil if @document['oclc']
   end
 
   configure_blacklight do |config|


### PR DESCRIPTION
## Context
Our initial understanding of HathiTrust's ETAS programme was that when we restored access to the print collection we would have to remove the HathiTrust ETAS links (i.e. ETAS is only allowed when there is no access to the print collection). Clarification from HathiTrust indicates that access to the print collection can be restored as long as ETAS items are not accessible.

We're going to suppress the hold button in Discovery whenever the record is in the overlap table, without regard for whether or not the item is actually still available via the HathiTrust API, and knowing that the overlap report is not currently being refreshed in a timely manner.

To be clear: this means that we 100% expect that there will be corner cases in which the hold button will be unavailable but no access in HathiTrust button will be present, because the item is unavailable through their API. This is not a bug, this is a compromise we are making to do this in a timely manner – users are expected to contact public services to resolve access to those items. Weiwei will communicate this expectation to public services.

Resolves #2003 

## What's New

If the item is in our Hathi Trust overlap report suppress the "Hold" button.

![with_hold_button](https://user-images.githubusercontent.com/1220762/87346874-7c5ef280-c50f-11ea-99b8-8f35effe6b83.JPG)
![without_hold_button](https://user-images.githubusercontent.com/1220762/87346876-7cf78900-c50f-11ea-9c98-0f5c389f7d6b.JPG)
