### PR TITLE
update bundler version in Docker for uat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Fixed
 - regression test of library count on advanced search page after reskin changed layout
-- update bundler version in Docker for uat
+- update bundler version in Docker for uat [#2030](https://github.com/ualbertalib/discovery/pull/2030)
 
 ## [3.3.1] - 2020-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Fixed
 - regression test of library count on advanced search page after reskin changed layout
+- update bundler version in Docker for uat
 
 ## [3.3.1] - 2020-06-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ ENV APP_ROOT /app
 RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
 
+# Update bundler
+RUN gem update --system
+RUN gem install bundler:2.1.4
+
 # Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
 COPY Gemfile  $APP_ROOT
 COPY Gemfile.lock $APP_ROOT


### PR DESCRIPTION
## Context

When we bumped the version of bundler in Gemfile.lock this started the builds on Docker hub failing. Updating
rubygems and installing the correct version of bundler should resolve this issue.

## What's New

Install the correct version of bundler in our Dockerfile.
