### PR TITLE
bump CHANGELOG and VERSION for 3.4.0 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.4.0] - 2020-07-20
+
 ### Changed
 - discourage holds placed on items with HathiTrust access [#2003](https://github.com/ualbertalib/discovery/issues/2003)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.3.1'.freeze # used in application layout meta generator tag
+  VERSION = '3.4.0'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
## Context
Prepare for 3.4.0 release with hold button suppressed for items in Hathi Trust report.

## What's New

Updated CHANGELOG and application.rb version.