### PR TITLE
remove span tag showing in facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- remove span tag showing in facets [#2011](https://github.com/ualbertalib/discovery/issues/2011)
+
 ## [3.4.0] - 2020-07-20
 
 ### Changed

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -4,7 +4,7 @@
                             param_name: Blacklight::Solr::FacetPaginator.request_keys[:page],
                             class: 'btn btn-link',
                             data: { ajax_modal: 'preserve' } do %>
-    <span class="disabled btn btn-disabled"><%= raw(t('views.pagination.previous')) %></span>
+        <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
   <% end %>
   <%= link_to_next_page @pagination,
                         raw(t('views.pagination.next')),
@@ -12,7 +12,7 @@
                         class: 'btn btn-link',
                         data: { ajax_modal: 'preserve' } do %>
 
-    <span class="disabled btn  btn-disabled"><%= raw(t('views.pagination.next')) %></span>
+<%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
   <% end %>
 </div>
 


### PR DESCRIPTION
## Context
![image](https://user-images.githubusercontent.com/1220762/88228034-c5a7f400-cc2b-11ea-8b2d-50833527f212.png)
Turns out this is a known problem and fixed in a 6.x version of Blacklight.  We don't have the interest to bump our blacklight version so patching instead.  Thanks @orangewolf for finding the solution!

Related to #2011 

## What's New
![image](https://user-images.githubusercontent.com/1220762/88227973-af9a3380-cc2b-11ea-971f-a098bfdb8448.png)




