### PR TITLE
Request Form updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Changed
+- updated RCRF pickup locations [#2038](https://github.com/ualbertalib/discovery/issues/2038)
+- updated BPSC retrieval request [#2037](https://github.com/ualbertalib/discovery/issues/2037)
+
 ### Fixed
 - remove span tag showing in facets [#2011](https://github.com/ualbertalib/discovery/issues/2011)
 

--- a/app/models/rcrf_special_request.rb
+++ b/app/models/rcrf_special_request.rb
@@ -2,18 +2,6 @@ class RCRFSpecialRequest
   include ActiveModel::Model
 
   # FIXME: Should be from database or something, probably duplication with locations.yml
-  NORMAL_LIBRARIES = [
-    'University of Alberta Augustana',
-    'University of Alberta Bibliothèque Saint-Jean',
-    'University of Alberta Cameron-Science & Technology',
-    'University of Alberta HT Coutts-Education and Kinesiology, Sport, and Recreation',
-    'University of Alberta JA Weir-Law',
-    'University of Alberta JW Scott-Health Sciences',
-    'University of Alberta Rutherford-Humanities & Social Science',
-    "University of Alberta St Joseph's College",
-    'University of Alberta Winspear-Business'
-  ].freeze
-
   # COVID-19: Curbside delivery is only at Rutherford
   LIBRARIES = [
     'University of Alberta Rutherford-Humanities & Social Science'

--- a/app/models/rcrf_special_request.rb
+++ b/app/models/rcrf_special_request.rb
@@ -2,16 +2,17 @@ class RCRFSpecialRequest
   include ActiveModel::Model
 
   # FIXME: Should be from database or something, probably duplication with locations.yml
+  # COVID-19: Curbside delivery is only at Rutherford
   LIBRARIES = [
-    'University of Alberta Augustana',
-    'University of Alberta Bibliothèque Saint-Jean',
-    'University of Alberta Cameron-Science & Technology',
-    'University of Alberta HT Coutts-Education and Kinesiology, Sport, and Recreation',
-    'University of Alberta JA Weir-Law',
-    'University of Alberta JW Scott-Health Sciences',
-    'University of Alberta Rutherford-Humanities & Social Science',
-    "University of Alberta St Joseph's College",
-    'University of Alberta Winspear-Business'
+  #  'University of Alberta Augustana',
+  #  'University of Alberta Bibliothèque Saint-Jean',
+  #  'University of Alberta Cameron-Science & Technology',
+  #  'University of Alberta HT Coutts-Education and Kinesiology, Sport, and Recreation',
+  #  'University of Alberta JA Weir-Law',
+  #  'University of Alberta JW Scott-Health Sciences',
+    'University of Alberta Rutherford-Humanities & Social Science'
+  #  "University of Alberta St Joseph's College",
+  #  'University of Alberta Winspear-Business'
   ].freeze
 
   attr_accessor :name,

--- a/app/models/rcrf_special_request.rb
+++ b/app/models/rcrf_special_request.rb
@@ -2,17 +2,21 @@ class RCRFSpecialRequest
   include ActiveModel::Model
 
   # FIXME: Should be from database or something, probably duplication with locations.yml
+  NORMAL_LIBRARIES = [
+    'University of Alberta Augustana',
+    'University of Alberta Bibliothèque Saint-Jean',
+    'University of Alberta Cameron-Science & Technology',
+    'University of Alberta HT Coutts-Education and Kinesiology, Sport, and Recreation',
+    'University of Alberta JA Weir-Law',
+    'University of Alberta JW Scott-Health Sciences',
+    'University of Alberta Rutherford-Humanities & Social Science',
+    "University of Alberta St Joseph's College",
+    'University of Alberta Winspear-Business'
+  ].freeze
+
   # COVID-19: Curbside delivery is only at Rutherford
   LIBRARIES = [
-  #  'University of Alberta Augustana',
-  #  'University of Alberta Bibliothèque Saint-Jean',
-  #  'University of Alberta Cameron-Science & Technology',
-  #  'University of Alberta HT Coutts-Education and Kinesiology, Sport, and Recreation',
-  #  'University of Alberta JA Weir-Law',
-  #  'University of Alberta JW Scott-Health Sciences',
     'University of Alberta Rutherford-Humanities & Social Science'
-  #  "University of Alberta St Joseph's College",
-  #  'University of Alberta Winspear-Business'
   ].freeze
 
   attr_accessor :name,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,9 +46,9 @@ en:
       review_policy_html:
         'Prior to your visit, please review our
         <a href="https://bpsc.library.ualberta.ca/info/visit#policy">Reading Room Policies.</a>'
-      date_of_planned_visit: 'Please indicate the first date of your planned visit. Public access hours are Monday-Friday
-        12:30-4:30pm. Facilities maintenance work is expected to cause intermittent closures this term, so please confirm
-        public access hours <a href="https://bpsc.library.ualberta.ca/">here</a>.'
+      date_of_planned_visit: 'Please note that the reading room in Bruce Peel Special Collections will remain closed through the 
+        fall term (2020) due to COVID-19 and in order to accommodate a large facilities project. Limited services are available. 
+        Updates and details can be found on the Peel website <a href="https://bpsc.library.ualberta.ca/">here</a>.'
       call_number: 'Call Number'
   rcrf_read_on_site_requests:
     new:


### PR DESCRIPTION
## Context

Library operations have been modified for public health reasons related to the Covid-19 pandemic.  Bruce Peel Special Collections remains closed with limited services available and RCRF requests are only available for pickup at Rutherford. 

Related to #2038 and #2039

## What's New

Updated the text for the BPSC form and changed the libraries available in the selection list for RCRF per email request and OTRS ticket.