### PR TITLE
Restored the prompt from a previous change to the BPSC request form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- missing first sentence in BPSC request [#2037](https://github.com/ualbertalib/discovery/issues/2037)
+
 ## [3.5.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.5.1]
+
 ### Fixed
 - missing first sentence in BPSC request [#2037](https://github.com/ualbertalib/discovery/issues/2037)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.5.0'.freeze # used in application layout meta generator tag
+  VERSION = '3.5.1'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
       review_policy_html:
         'Prior to your visit, please review our
         <a href="https://bpsc.library.ualberta.ca/info/visit#policy">Reading Room Policies.</a>'
-      date_of_planned_visit: 'Please note that the reading room in Bruce Peel Special Collections will remain closed through the 
+      date_of_planned_visit: 'Please indicate the first date of your planned visit. Please note that the reading room in Bruce Peel Special Collections will remain closed through the 
         fall term (2020) due to COVID-19 and in order to accommodate a large facilities project. Limited services are available. 
         Updates and details can be found on the Peel website <a href="https://bpsc.library.ualberta.ca/">here</a>.'
       call_number: 'Call Number'


### PR DESCRIPTION
## Context

There was just a minor change requested to a previous change on the BPSC request form.  The text change was missing the prompt https://github.com/ualbertalib/discovery/issues/2037#issuecomment-675047778

Related to #2037 

## What's New

Edit the text for the form.  Bump for a new release.