### PR TITLE
Default translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Security
+- bump blacklight for CVE-2020-15169 [PR#]()
+
 ### Changed
-- revert bump to bundler from 2.1.4 to 1.17.3 [#PR]()
+- revert bump to bundler from 2.1.4 to 1.17.3 [PR#]()
 
 ## [3.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Changed
+- revert bump to bundler from 2.1.4 to 1.17.3 [#PR]()
+
 ## [3.5.1]
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,6 @@ ENV APP_ROOT /app
 RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
 
-# Update bundler
-RUN gem update --system
-RUN gem install bundler:2.1.4
-
 # Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
 COPY Gemfile  $APP_ROOT
 COPY Gemfile.lock $APP_ROOT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ualbertalib/blacklight
-  revision: 0a10731226978a986698c623163dbd14d0c16a4c
+  revision: 3819e9d1d4a79041bff458ee87f62cee354b7411
   specs:
     blacklight (5.15.0)
       bootstrap (~> 4.3.1)
@@ -74,7 +74,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     arel (6.0.4)
     ast (2.4.0)
-    autoprefixer-rails (9.5.1.1)
+    autoprefixer-rails (9.8.6.3)
       execjs
     bcrypt (3.1.13)
     better_errors (2.7.1)
@@ -168,7 +168,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
-    ffi (1.13.0)
+    ffi (1.13.1)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
     generator_spec (0.9.4)
@@ -209,7 +209,7 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.5.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -220,7 +220,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     multi_json (1.13.1)
     multipart-post (2.1.1)
     mysql2 (0.4.10)
@@ -243,7 +243,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     parslet (1.8.2)
-    popper_js (1.14.5)
+    popper_js (1.16.0)
     powerpack (0.1.2)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -372,10 +372,10 @@ GEM
       stomp
       xml-simple
     spring (2.1.1)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -384,7 +384,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,4 +461,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
## Context

We're not going to get upstream updates for Rails 4.2 and we've pinned blacklight so we've made the changes there and now we need to use them in discovery.

It looks like bundler 2.x is not compatible with Rails 4.2.  I'm not sure what combination of things gave me the impression that we could do the bump before.

Related to CVE-2020-15169 and https://github.com/ualbertalib/blacklight/pull/5

## What's New

Revert bundler to 1.17.3 and bump blacklight