### PR TITLE
added oclc number to symphony indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Added
+- oclc number to symphony indexing [#2050](https://github.com/ualbertalib/discovery/issues/2050)
+
 ### Security
 - bump blacklight for CVE-2020-15169 [PR#2056](https://github.com/ualbertalib/discovery/pull/2056)
 

--- a/config/SolrMarc/symphony_index.properties
+++ b/config/SolrMarc/symphony_index.properties
@@ -21,6 +21,7 @@ isbn_t = 020a, (pattern_map.isbn_clean)
 isbn_cancelled_tim = 020z, (pattern_map.isbn_clean)
 issn_t = 022a, first
 issn_alternative_t = 022y
+oclc_number_t = 035a
 material_type_display = custom, removeTrailingPunct(300aa)
 size_tesim = custom, removeTrailingPunct(300c)
 description_tesim = custom, removeTrailingPunct(300b)


### PR DESCRIPTION
## Context

Concordia library uses WorldCat Local, and OCLC does not index our 001 cataloguing key. This means, they can't link directly to an item for hold-placing purposes. They can use the OCLC number, which is indexed in WorldCat Local, but we currently don't index that field. If we index that field, we may be able to come up with a solution for them to build a working place hold link.

Related to #2050 https://github.com/ualbertalib/blacklight_solr_conf/pull/8

## What's New

index `035a` as `oclc_number_t`
