### PR TITLE
circuit breaker to SFX ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Added
 - oclc number to symphony indexing [#2050](https://github.com/ualbertalib/discovery/issues/2050)
+- circuit breaker to SFX ingest [#1875](https://github.com/ualbertalib/discovery/issues/1875)
 
 ### Security
 - bump blacklight for CVE-2020-15169 [PR#2056](https://github.com/ualbertalib/discovery/pull/2056)

--- a/config/ingest.yml
+++ b/config/ingest.yml
@@ -102,7 +102,7 @@ database_test_set:
   vocabulary: DatabaseVocabulary
   mode: file
   expand_path: "spec/fixtures/database_test_set.xml"
-  path: "spec/fixtures/databases_test_set.xml"
+  path: "spec/fixtures/database_test_set.xml"
   test: true
 
 services:

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -46,7 +46,7 @@ task :ingest, [:collection] => [:update_solr_marc_maps] do |_t, args|
   @c = IngestConfiguration.new(args.collection, @config_file)
 
   # store a copy before it's replaced
-  File.rename(Rails.root.join(@c.path), Rails.root.join(@c.path + '.bak')) if @c.endpoint
+  File.rename(Rails.root.join(@c.path), Rails.root.join(@c.path + '.bak')) if @c.endpoint && File.exist?(Rails.root.join(@c.path))
   Rake::Task['fetch'].invoke("#{@c.endpoint}|#{@c.path}") if @c.endpoint
 
   # circuit breaker to prevent unparsable data from changing our index

--- a/spec/fixtures/database_test_set.xml
+++ b/spec/fixtures/database_test_set.xml
@@ -504,3 +504,5 @@ Also includes full text from a number of journals, conference proceedings, and r
   <enableproxy type="integer">0</enableproxy>
   <languagenote>English</languagenote>
 </hash>
+</databases>
+</root>


### PR DESCRIPTION
## Context

Ocassionally we'll get a response from https://sfx-resolver.hosted.exlibrisgroup.com/resolver/cgi/public/get_file.cgi?file=sfxdata.xml that isn't utf-8 encoded and it ends up clearing out all our e-journals. Backing up the existing file and exiting if the new file isn't parsable should give us some more warning.

Also noticed some errors in the database_test_set so fixed that too.

Related to #1875 

## What's New

Fixed database_test_set and added circuit breaker for sfx ingest.
