### PR TITLE
monkey patch rake CVE-2020-8181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Security
 - bump blacklight for CVE-2020-15169 [PR#2056](https://github.com/ualbertalib/discovery/pull/2056)
+- monkeypatch rack for CVE-2020-8161 [PR#2060](https://github.com/ualbertalib/discovery/pull/2060)
 
 ### Changed
 - revert bump to bundler from 2.1.4 to 1.17.3 [PR#2056](https://github.com/ualbertalib/discovery/pull/2056)

--- a/config/initializers/cve-2020-8161.rb
+++ b/config/initializers/cve-2020-8161.rb
@@ -1,0 +1,31 @@
+# https://groups.google.com/forum/#!topic/rubyonrails-security/IOO1vNZTzPA
+# but adapted for Rack 1.6-stable https://github.com/rack/rack/blob/47a1fd73fc77f094573f4215b0fc884f4ac1c03c/lib/rack/directory.rb#L79-L105
+
+Rack::Directory.prepend(Module.new do
+  def list_directory
+    @files = [['../','Parent Directory','','','']] 
+
+    url_head = (@script_name.split('/') + @path_info.split('/')).map do |part|
+      Rack::Utils.escape part
+    end 
+
+    Dir.entries(@path).reject { |e| e.start_with?('.') }.sort.each do |node|
+      stat = stat(node)
+      next  unless stat
+      basename = F.basename(node)
+      ext = F.extname(node) 
+
+      url = F.join(*url_head + [Rack::Utils.escape(basename)])
+      size = stat.size
+      type = stat.directory? ? 'directory' : Mime.mime_type(ext)
+      size = stat.directory? ? '-' : filesize_format(size)
+      mtime = stat.mtime.httpdate
+      url << '/'  if stat.directory?
+      basename << '/'  if stat.directory?   
+
+      @files << [ url, basename, size, type, mtime ]
+    end
+  
+    return [ 200, { CONTENT_TYPE =>'text/html; charset=utf-8'}, self ]
+  end
+end)

--- a/config/initializers/cve-2020-8161.rb
+++ b/config/initializers/cve-2020-8161.rb
@@ -3,17 +3,18 @@
 
 Rack::Directory.prepend(Module.new do
   def list_directory
-    @files = [['../','Parent Directory','','','']] 
+    @files = [['../', 'Parent Directory', '', '', '']]
 
     url_head = (@script_name.split('/') + @path_info.split('/')).map do |part|
       Rack::Utils.escape part
-    end 
+    end
 
     Dir.entries(@path).reject { |e| e.start_with?('.') }.sort.each do |node|
       stat = stat(node)
-      next  unless stat
+      next unless stat
+
       basename = F.basename(node)
-      ext = F.extname(node) 
+      ext = F.extname(node)
 
       url = F.join(*url_head + [Rack::Utils.escape(basename)])
       size = stat.size
@@ -21,11 +22,11 @@ Rack::Directory.prepend(Module.new do
       size = stat.directory? ? '-' : filesize_format(size)
       mtime = stat.mtime.httpdate
       url << '/'  if stat.directory?
-      basename << '/'  if stat.directory?   
+      basename << '/' if stat.directory?
 
-      @files << [ url, basename, size, type, mtime ]
+      @files << [url, basename, size, type, mtime]
     end
-  
-    return [ 200, { CONTENT_TYPE =>'text/html; charset=utf-8'}, self ]
+
+    [200, { CONTENT_TYPE => 'text/html; charset=utf-8' }, self]
   end
 end)


### PR DESCRIPTION
## Context

A directory traversal vulnerability exists in rack < 2.2.0 that allows an attacker perform directory traversal vulnerability in the Rack::Directory app that is bundled with Rack which could result in information disclosure.

We don't appear to use Rack::Directory in the application but monkey patching will ensure we're covered.

## What's New

monkey patch Rack::Directory#list_directory like https://groups.google.com/forum/#!topic/rubyonrails-security/IOO1vNZTzPA says but adapted for Rack 1.6-stable https://github.com/rack/rack/blob/47a1fd73fc77f094573f4215b0fc884f4ac1c03c/lib/rack/directory.rb#L79-L105

