### PR TITLE
discovery.uat.library.ualberta.ca

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ### Changed
 - revert bump to bundler from 2.1.4 to 1.17.3 [PR#2056](https://github.com/ualbertalib/discovery/pull/2056)
+- discovery.uat.library.ualberta.ca etc via nginx-proxy [1724](https://github.com/ualbertalib/jupiter/issues/1724)
 
 ## [3.5.1]
 

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -1,4 +1,4 @@
-Rails.application.routes.default_url_options = { host: 'uat.library.ualberta.ca', port: 3002 }
+Rails.application.routes.default_url_options = { host: 'discovery.uat.library.ualberta.ca' }
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,16 +22,20 @@ services:
     image: ualbertalib/blacklight_solr_conf
     environment:
       - SOLR_HEAP=2g
+      - VIRTUAL_HOST=solr.discovery.uat.library.ualberta.ca
     volumes:
       - solr:/opt/solr/server/solr/mycores
     ports:
-      - "8983:8983"
+      - "8983"
 
   mailcatcher:
     image: sj26/mailcatcher
+    environment:
+      - VIRTUAL_HOST=mail.discovery.uat.library.ualberta.ca
+      - VIRTUAL_PORT=1080
     ports:
-      - "1025:1025"
-      - "3082:1080"
+      - "1025"
+      - "1080"
 
   # Rails
   web:
@@ -39,6 +43,7 @@ services:
     image: ualbertalib/discovery:uat
     volumes:
       - assets:/app/public/assets/
+      - ../discoveryData:/app/data
     command: bundle exec puma -e uat
     env_file: .env_deployment
     depends_on:
@@ -55,4 +60,4 @@ services:
       - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
       - assets:/app/public/assets/
     ports:
-      - "3002:80"
+      - "80"


### PR DESCRIPTION
## Context

Distinct server names or routes to applications instead of port ‘x’ is Jupiter, port ‘y’ is avalon, etc. Personally, I find names easier to remember than numbers. If the applications are containerised, a reverse proxy could handle the routing.

nginx-proxy is doing the routing for us.

Related to https://github.com/ualbertalib/jupiter/issues/1724

## What's New

docker-compose.yml with environment variables that nginx-proxy is expecting.  Changed the default_url to reflect the discovery subdomain.