### PR TITLE
Circuit breaker memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 sudo: required
 addons:
   chrome: stable
+    apt:
+      packages:
+        # Needed for `xmllint`.
+        - libxml2-utils
 rvm:
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: ruby
 addons:
   chrome: stable
-    apt:
-      packages:
-      # Needed for `xmllint`.
-      - libxml2-utils
+  apt:
+    packages:
+    - libxml2-utils
 rvm:
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: required
 addons:
   chrome: stable
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ addons:
   chrome: stable
     apt:
       packages:
-        # Needed for `xmllint`.
-        - libxml2-utils
+      # Needed for `xmllint`.
+      - libxml2-utils
 rvm:
   - 2.5
   - 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ## [Unreleased]
 
 ### Fixed
-- memory use by circuit breaker []()
+- memory use by circuit breaker [PR#2067](https://github.com/ualbertalib/discovery/pull/2067)
 
 ## [3.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- memory use by circuit breaker []()
+
 ## [3.5.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.5.3]
+
 ### Fixed
 - memory use by circuit breaker [PR#2067](https://github.com/ualbertalib/discovery/pull/2067)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ discovery platform. Based on [Project Blacklight](projectblacklight.org).
 
 *   Depends on [Ruby](https://www.ruby-lang.org/en/) 2.5.x
 *   Depends on Java (for SolrMarc and Ingestion scripts)
+*   Depends on [xmllint](http://xmlsoft.org/xmllint.html) (for SFX Ingestion scripts) which is available in `sudo apt install libxml2-utils` on Ubuntu.
 *   Depends on an instance of [Solr](https://lucene.apache.org/solr/) with [this configuration](https://github.com/ualbertalib/blacklight_solr_conf)
 *   If you wish to use docker for the datastores install [docker](https://docs.docker.com/install/) and [docker-compose](https://docs.docker.com/compose/install/) first.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.5.2'.freeze # used in application layout meta generator tag
+  VERSION = '3.5.3'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
## Context

`rake ingest[sfx]` after adding the circuit breaker caused the ingest script to run out of memory:
```
rake aborted!
Errno::ENOMEM: Cannot allocate memory - java
```
> Kilmarnock in Prod  has 4Gb memory / 2Gb swap and performs this feat monthly without complaint.
Forest has the same virtual h/w, but was throwing off Netdata alarms about memory & swap usage while ingesting SFX specifically

Basically we read the file twice with two different GC'd languages, thus the file's in memory twice.  oops

Related to #1875 

## What's New

Outsource the validation check to [xmllint](http://xmlsoft.org/xmllint.html) using Ruby library [Open3](https://devdocs.io/ruby~2.6/open3).