### PR TITLE
fix memory use and bump for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [3.5.4]
 
-## Fixed
+### Fixed
 - memory use by circuit breaker (--stream) [PR#2069](https://github.com/ualbertalib/discovery/pull/2069)
 
 ## [3.5.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.5.4]
+
+## Fixed
+- memory use by circuit breaker (--stream) []()
+
 ## [3.5.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 ## [3.5.4]
 
 ## Fixed
-- memory use by circuit breaker (--stream) []()
+- memory use by circuit breaker (--stream) [PR#2069](https://github.com/ualbertalib/discovery/pull/2069)
 
 ## [3.5.3]
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.5.3'.freeze # used in application layout meta generator tag
+  VERSION = '3.5.4'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/lib/tasks/ingest.rake
+++ b/lib/tasks/ingest.rake
@@ -52,7 +52,7 @@ task :ingest, [:collection] => [:update_solr_marc_maps] do |_t, args|
 
   # circuit breaker to prevent unparsable data from changing our index
   if File.extname(Rails.root.join(@c.path)) == '.xml'
-    Open3.popen3("xmllint --encode utf-8 --noout #{Rails.root.join(@c.path)}") do |_stdout, _stderr, status, _thread|
+    Open3.popen3("xmllint --encode utf-8 --stream --noout #{Rails.root.join(@c.path)}") do |_stdout, _stderr, status, _thread|
       response = status.read
       unless response.empty?
         unparsable = "#{@c.path} is unparsable #{response}"


### PR DESCRIPTION
## Context

After the last "fix" the large file continued to have issues.  Found the --stream flag for xmllint and it seems to have solved the mystery.

From `man xmllint`
```
--stream
Use streaming API - useful when used in combination with --relaxng or --valid options for validation of files that are too large to be held in memory.
```

Related to #1875

## What's New

use `--stream` flag when invoking `xmllint` on large sfx ingest files.
