### PR TITLE
add xmllint to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -qq \
                           nodejs \
                           yarn \
                           tzdata \
+                          libxml2-utils \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
## Context

Docker web container needs xmllint installed

Related to #2067 

## What's New

Install prerequisite.
