### PR TITLE
Revert "skip these tests only on travis CI"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -8,6 +8,4 @@ Related to # (issue)
 
 Please summarize what's new or changed in this PR.
 
-- [ ] `rake spec` tests pass
-
 Remember to request a reviewer when you submit! 

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -17,14 +17,12 @@ RSpec.describe 'Catalog Search', type: :feature do
     end
   end
 
-  unless ENV['TRAVIS']
-    scenario 'User visits an SFX item result' do
-      VCR.use_cassette('sfx_result') do
-        visit 'catalog/954921333008'
-        expect(page).to have_text('Accountancy') # title
-        expect(page).to have_link('Business Source Complete') # Subscription
-        expect(page).to have_link('Factiva') # Subscription
-      end
+  scenario 'User visits an SFX item result' do
+    VCR.use_cassette('sfx_result') do
+      visit 'catalog/954921333008'
+      expect(page).to have_text('Accountancy') # title
+      expect(page).to have_link('Business Source Complete') # Subscription
+      expect(page).to have_link('Factiva') # Subscription
     end
   end
 end

--- a/spec/features/item_holding_table_spec.rb
+++ b/spec/features/item_holding_table_spec.rb
@@ -16,16 +16,14 @@ RSpec.describe 'Item has proper holding table', type: :feature do
     end
   end
 
-  unless ENV['TRAVIS']
-    scenario 'Sfx item has proper holding table' do
-      VCR.use_cassette('item_sfx_holding_table') do
-        visit '/catalog/954921333007'
+  scenario 'Sfx item has proper holding table' do
+    VCR.use_cassette('item_sfx_holding_table') do
+      visit '/catalog/954921333007'
 
-        page.assert_selector('#holdings table td', count: 5)
-        expect(first('#holdings table td')).to have_link('Business Source Complete', href: 'http://login.ezproxy.library.ualberta.ca/login?url=https://search.ebscohost.com/direct.asp?db=bth&jn=AMJ&scope=site')
-        expect(first('#holdings table td')).to have_text('coverage: Available from 1963.')
-        expect(first('#holdings table td')).to have_css("iframe[src='https://tal.scholarsportal.info/alberta/sfx/?tag=EBSCOhost_LHCADL']")
-      end
+      page.assert_selector('#holdings table td', count: 5)
+      expect(first('#holdings table td')).to have_link('Business Source Complete', href: 'http://login.ezproxy.library.ualberta.ca/login?url=https://search.ebscohost.com/direct.asp?db=bth&jn=AMJ&scope=site')
+      expect(first('#holdings table td')).to have_text('coverage: Available from 1963.')
+      expect(first('#holdings table td')).to have_css("iframe[src='https://tal.scholarsportal.info/alberta/sfx/?tag=EBSCOhost_LHCADL']")
     end
   end
 

--- a/spec/features/item_ill_link_spec.rb
+++ b/spec/features/item_ill_link_spec.rb
@@ -1,11 +1,9 @@
 RSpec.describe 'Link to ill', type: :feature do
-  unless ENV['TRAVIS']
-    scenario 'Sfx item has link to ill' do
-      VCR.use_cassette('item_ill_link') do
-        visit '/catalog/954921333007'
+  scenario 'Sfx item has link to ill' do
+    VCR.use_cassette('item_ill_link') do
+      visit '/catalog/954921333007'
 
-        expect(page).to have_link('ill', href: %r{https://license-terms.library.ualberta.ca\/terms\/})
-      end
+      expect(page).to have_link('ill', href: %r{https://license-terms.library.ualberta.ca\/terms\/})
     end
   end
   scenario 'Non-sfx item does not have link to ill' do


### PR DESCRIPTION
Reverts ualbertalib/discovery#2082

maybe we shouldn’t skip those tests, then. sounds like there’s an actual non-CI issue here