### PR TITLE
Symphony nightly migration foreign key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- symphony_nightly migration foreign key error [2142](https://github.com/ualbertalib/discovery/issues/2142)
+
 ## [3.5.6] - 2021-01-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+## [3.5.7] - 2021-01-15
+
 ### Fixed
 - symphony_nightly migration foreign key error [2142](https://github.com/ualbertalib/discovery/issues/2142)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require 'csv'
 Bundler.require(*Rails.groups)
 
 module Discovery
-  VERSION = '3.5.6'.freeze # used in application layout meta generator tag
+  VERSION = '3.5.7'.freeze # used in application layout meta generator tag
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/docker-compose.lightweight.yml
+++ b/docker-compose.lightweight.yml
@@ -12,7 +12,7 @@ volumes:
 
 services:
   mysql:
-    image: mysql:5.7
+    image: mysql:5.5 # matches staging/production
     environment:
       MYSQL_ROOT_PASSWORD: mysecretpassword
     volumes:

--- a/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
+++ b/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
@@ -16,8 +16,8 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
     # Creating the locations table later on without this gives errors that were
     # difficult to to make sense of.
     foreign_keys('backup_locations').each do |fkey|
+      remove_foreign_key fkey.from_table, column: fkey.options[:column]
       rename_column      fkey.from_table, fkey.options[:column], 'backup_' + fkey.options[:column]
-      remove_foreign_key fkey.from_table, fkey.to_table
       add_foreign_key    fkey.from_table, fkey.to_table
     end
 
@@ -56,8 +56,8 @@ class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Mi
     end
 
     foreign_keys('locations').each do |fkey|
+      remove_foreign_key fkey.from_table, column: fkey.options[:column]
       rename_column      fkey.from_table, fkey.options[:column], fkey.options[:column].gsub('backup_', '')
-      remove_foreign_key fkey.from_table, fkey.to_table
       add_foreign_key    fkey.from_table, fkey.to_table
     end
 


### PR DESCRIPTION
## Context

We're trying to automate data flowing from Symphony configuration files to Discovery to provide user better labels in the holdings table.

When we tried the two steps (`rails g symphony_nightly` `rake db:migrate`) in staging/production we encountered a failure in the migration and complains about foreign key constraints.  There was a bug in the migration template that was hidden in development/test because a different, more tolerant version of MySQL was being used (5.7 vs 5.5 in production)

Related to #2142 

## What's New

- fixed symphony_nightly migration foreign key error 
- bump version for new release