### PR TITLE
Added rails version to symphony nightly template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in Discovery project adheres to [Semantic Versioning](http://semver
 
 ## [Unreleased]
 
+### Fixed
+- Added rails version to symphony nightly template []()
+
 ## [3.5.7] - 2021-01-15
 
 ### Fixed

--- a/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
+++ b/lib/generators/symphony_nightly/templates/update_symphony_nightly.erb
@@ -1,4 +1,4 @@
-class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Migration
+class UpdateSymphonyNightly<%= Time.now.strftime('%Y%m%d') %> < ActiveRecord::Migration[4.2]
   # order matters for libraries and locations because of the foreign key
   SYMPHONY_TABLES = ['statuses',
                      'item_types',


### PR DESCRIPTION
## Context

Both Discovery and NEOSDiscovery use Symphony configuration data to provide human readable string in the holding table. Additionaly NEOSDiscovery has library/location relationships. We now have this data flowing into Discovery but we need this to continue to flow into NEOSDiscovery. One way to do this would be to use the same migrations on both applications.

Related to https://github.com/ualbertalib/NEOSDiscovery/issues/352

## What's New

A Rails version is required by Rails 5.2 and would allow us to share the db migrations with both Discovery and NEOSDiscovery apps.